### PR TITLE
Add TUI remote plugin search with Hermes parity

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,6 +543,11 @@ edgecrab plugins update
 edgecrab plugins remove github-tools
 ```
 
+Inside the TUI, `/plugins search ...` and `/plugins browse` now open the same
+kind of async remote browser EdgeCrab already uses for skills and MCP:
+fuzzy filtering, background search, split-detail view, and one-key install or
+replace from official registries.
+
 EdgeCrab now supports four plugin kinds:
 
 - `skill` plugins load `SKILL.md` content from `~/.edgecrab/plugins/<name>/` into the session prompt with Hermes-compatible frontmatter, readiness checks, and platform filtering.

--- a/crates/edgecrab-cli/src/main.rs
+++ b/crates/edgecrab-cli/src/main.rs
@@ -1114,7 +1114,6 @@ fn run_plugins(command: PluginsCommand) -> anyhow::Result<()> {
             name,
             force,
             no_enable,
-            replace_existing: false,
         })?,
         PluginsCommand::Enable { name } => {
             plugins_cmd::run(plugins_cmd::PluginAction::Enable { name })?

--- a/crates/edgecrab-cli/src/main.rs
+++ b/crates/edgecrab-cli/src/main.rs
@@ -1114,6 +1114,7 @@ fn run_plugins(command: PluginsCommand) -> anyhow::Result<()> {
             name,
             force,
             no_enable,
+            replace_existing: false,
         })?,
         PluginsCommand::Enable { name } => {
             plugins_cmd::run(plugins_cmd::PluginAction::Enable { name })?

--- a/crates/edgecrab-cli/tests/mcp_e2e.rs
+++ b/crates/edgecrab-cli/tests/mcp_e2e.rs
@@ -314,6 +314,7 @@ fn mcp_auth_reports_dynamic_loopback_redirects_for_browser_flow() {
         .arg(&config_path)
         .args(["mcp", "auth", "oauth-browser"])
         .env("HOME", home.path())
+        .env("EDGECRAB_DISABLE_BROWSER_LAUNCH", "1")
         .output()
         .expect("run edgecrab");
 


### PR DESCRIPTION
## Summary
- add a real remote plugin browser for `/plugins search` and `/plugins browse` in the TUI
- share plugin search parsing/install flows across CLI and TUI, including Hermes source targeting
- add Hermes bridge e2e coverage plus spec, README, docs, changelog, and site updates

## Validation
- EDGECRAB_DISABLE_BROWSER_LAUNCH=1 cargo test
- cargo clippy -- -D warnings
- pnpm install --frozen-lockfile
- pnpm build