### PR TITLE
fix(local-harness): flat patch schema fixes LM Studio GEN=0

### DIFF
--- a/crates/edgecrab-cli/src/main.rs
+++ b/crates/edgecrab-cli/src/main.rs
@@ -203,7 +203,13 @@ fn explicit_provider_request(model: &str) -> Option<(&str, &str)> {
 }
 
 async fn prepare_super_grok_oauth_env() -> anyhow::Result<()> {
-    let auth_path = edgecrab_proxy::default_auth_path();
+    if std::env::var("XAI_API_KEY")
+        .ok()
+        .is_some_and(|v| !v.trim().is_empty())
+    {
+        return Ok(());
+    }
+    let auth_path = edgecrab_proxy::auth_path_for_provider(edgecrab_proxy::XAI_OAUTH_PROVIDER);
     let (bearer, base_url) = edgecrab_proxy::resolve_xai_credentials_async(
         &auth_path,
         edgecrab_proxy::XAI_OAUTH_PROVIDER,
@@ -212,7 +218,15 @@ async fn prepare_super_grok_oauth_env() -> anyhow::Result<()> {
         false,
     )
     .await
-    .map_err(|e| anyhow!("SuperGrok OAuth unavailable: {e}"))?;
+    .map_err(|e| {
+        anyhow!(
+            "SuperGrok OAuth unavailable: {e}\n\
+             Active profile likely uses super-grok. Fix one of:\n\
+               edgecrab auth add grok     # browser OAuth → ~/.edgecrab/auth.json\n\
+               /profile use default       # switch to ollama (or another profile)\n\
+               export XAI_API_KEY=...     # static xAI API key"
+        )
+    })?;
 
     // SAFETY: Provider construction intentionally updates process-wide env credentials.
     unsafe {

--- a/crates/edgecrab-cli/src/status_bar.rs
+++ b/crates/edgecrab-cli/src/status_bar.rs
@@ -163,9 +163,8 @@ pub fn render_status_bar(frame: &mut Frame, area: Rect, params: &StatusBarRender
                 let elapsed_secs = started.elapsed().as_secs();
                 let long_label = params
                     .turn_activity
-                    .llm_wait_label()
-                    .map(|label| edgecrab_core::safe_truncate(label, 42).to_string())
-                    .unwrap_or_else(|| "waiting for first token".to_string());
+                    .llm_wait_compact_label()
+                    .unwrap_or("waiting for first token");
                 let msg = format_waiting_first_token_status(
                     params.theme,
                     params.status_indicator,

--- a/crates/edgecrab-cli/src/turn_activity.rs
+++ b/crates/edgecrab-cli/src/turn_activity.rs
@@ -140,6 +140,8 @@ pub struct TurnActivityState {
     pub hint: Option<String>,
     /// Human-readable detail for blocking non-streaming LLM waits (LM Studio, Ollama).
     pub llm_wait_detail: Option<String>,
+    /// Short status-bar label for the same wait (no mid-word truncation).
+    pub llm_wait_compact: Option<String>,
     /// Short rolling notices (long-run charms, onboarding) — Hermes Activity feed.
     pub activity_feed: Vec<ActivityNotice>,
     long_run_hints_per_tool: HashMap<String, usize>,
@@ -171,6 +173,7 @@ impl TurnActivityState {
             tool_token_acc: 0,
             hint: None,
             llm_wait_detail: None,
+            llm_wait_compact: None,
             activity_feed: Vec::new(),
             long_run_hints_per_tool: HashMap::new(),
             long_run_last_at: HashMap::new(),
@@ -202,6 +205,7 @@ impl TurnActivityState {
         self.tool_token_acc = 0;
         self.hint = None;
         self.llm_wait_detail = None;
+        self.llm_wait_compact = None;
         self.activity_feed.clear();
         self.long_run_hints_per_tool.clear();
         self.long_run_last_at.clear();
@@ -217,6 +221,7 @@ impl TurnActivityState {
             self.set_phase(ShelfPhase::Streaming);
         }
         self.llm_wait_detail = None;
+        self.llm_wait_compact = None;
     }
 
     /// Clear in-flight streamed tool draft UI (non-streaming retry / stall abort).
@@ -239,6 +244,9 @@ impl TurnActivityState {
         let detail = edgecrab_tools::tool_progress_tail::llm_wait_progress_label(
             provider, elapsed_secs, has_tools, ctx,
         );
+        self.llm_wait_compact = Some(edgecrab_tools::tool_progress_tail::llm_wait_status_compact(
+            provider, has_tools, ctx,
+        ));
         self.llm_wait_detail = Some(detail.clone());
         self.set_phase(ShelfPhase::AwaitingFirstToken);
         let tone = if elapsed_secs >= 45 {
@@ -283,11 +291,16 @@ impl TurnActivityState {
     }
 
     /// Short label for status bar / ghost line during blocking LLM waits.
+    pub fn llm_wait_compact_label(&self) -> Option<&str> {
+        self.llm_wait_compact.as_deref()
+    }
+
+    /// Full shelf line during blocking LLM waits (activity feed).
     pub fn llm_wait_label(&self) -> Option<&str> {
         self.llm_wait_detail.as_deref().or_else(|| {
             self.activity_feed.iter().rev().find_map(|n| {
                 let t = n.text.as_str();
-                if t.contains("composing") || t.contains("non-streaming") {
+                if t.contains("composing") || t.contains("non-streaming") || t.contains("Bedrock") {
                     Some(t)
                 } else {
                     None

--- a/crates/edgecrab-core/src/agent.rs
+++ b/crates/edgecrab-core/src/agent.rs
@@ -251,6 +251,8 @@ pub struct AgentConfig {
     pub max_write_payload_kib: Option<u32>,
     /// Default `write_file` create_dirs when the model omits the flag (local homelab paths).
     pub local_write_create_dirs: bool,
+    /// Absolute completion cap for local tool turns (yaml; env overrides).
+    pub local_max_tool_turn_tokens: usize,
     /// Per-turn file-mutation footers (success log + failure advisory).
     pub file_mutation_verifier: bool,
     /// Cross-session Anthropic prompt prefix cache (stable/dynamic split + TTL).
@@ -329,6 +331,8 @@ impl Default for AgentConfig {
             result_turn_budget_chars: 200_000,
             max_write_payload_kib: None,
             local_write_create_dirs: true,
+            local_max_tool_turn_tokens:
+                edgecrab_tools::mutation_turn_policy::LOCAL_TOOL_TURN_ABS_MAX_TOKENS,
             file_mutation_verifier: true,
             cache: crate::config::CacheConfig::default(),
             web_search: crate::config::WebSearchConfig::default(),
@@ -496,6 +500,7 @@ impl AgentConfig {
                 self.local_write_create_dirs,
                 &self.model,
             ),
+            local_max_tool_turn_tokens: self.local_max_tool_turn_tokens,
             web_search: edgecrab_tools::config_ref::WebSearchConfigRef {
                 primary: self.web_search.primary.clone(),
                 fallbacks: self.web_search.fallbacks.clone(),
@@ -2589,6 +2594,7 @@ impl AgentBuilder {
                 result_turn_budget_chars: config.tools.result_turn_budget_chars,
                 max_write_payload_kib: config.tools.file.max_write_payload_kib,
                 local_write_create_dirs: config.local_inference.write_create_dirs,
+                local_max_tool_turn_tokens: config.local_inference.max_tool_turn_tokens,
                 file_mutation_verifier: config.display.file_mutation_verifier,
                 cache: config.cache.clone(),
                 web_search: config.web_search.clone(),

--- a/crates/edgecrab-core/src/config.rs
+++ b/crates/edgecrab-core/src/config.rs
@@ -89,12 +89,16 @@ pub struct LocalInferenceConfig {
     /// When true, `write_file` treats omitted `create_dirs` as true (nested homelab paths).
     /// Default **true**; auto-enabled on lmstudio/ollama even when set false in yaml.
     pub write_create_dirs: bool,
+    /// Absolute completion cap for local tool turns (`max_tokens` on lmstudio/ollama).
+    /// Override precedence: `EDGECRAB_LOCAL_TOOL_MAX_TOKENS` env > this field > compile-time default.
+    pub max_tool_turn_tokens: usize,
 }
 
 impl Default for LocalInferenceConfig {
     fn default() -> Self {
         Self {
             write_create_dirs: true,
+            max_tool_turn_tokens: edgecrab_tools::mutation_turn_policy::LOCAL_TOOL_TURN_ABS_MAX_TOKENS,
         }
     }
 }

--- a/crates/edgecrab-core/src/conversation.rs
+++ b/crates/edgecrab-core/src/conversation.rs
@@ -1856,14 +1856,52 @@ impl Agent {
             // stable zone (8K-12K tokens of binary constants) is cached across
             // sessions.  The combined prompt keeps the stable zone as a prefix so
             // split_dynamic_from_stable() can safely extract the dynamic suffix.
-            // Build API messages, optionally appending ephemeral goal context as a
-            // user-role message (cache-safe — never mutates cached_system_prompt).
+            // Build API messages, optionally appending ephemeral goal context and local
+            // tool-turn geometry nudges as user-role messages (cache-safe).
             let goal_block = crate::goals::render_goal_block(
                 &self
                     .goal_store
                     .active(&conversation_session_id)
                     .unwrap_or_default(),
             );
+            let base_completion_options = completion_options_for(&config);
+            let max_mutation_payload_bytes = app_config_ref.max_write_payload_bytes();
+            let local_abs_max = app_config_ref.local_max_tool_turn_tokens;
+            let completion_options = crate::local_provider_policy::effective_completion_options(
+                &base_completion_options,
+                effective_provider.as_ref(),
+                !active_tool_defs.is_empty(),
+                max_mutation_payload_bytes,
+                local_abs_max,
+            );
+            let prompt_tokens_for_plan = estimate_request_prompt_tokens(
+                session.cached_system_prompt.as_deref(),
+                &session.messages,
+                &active_tool_defs,
+            );
+            let local_tool_turn_plan = if active_tool_defs.is_empty() {
+                None
+            } else {
+                crate::local_provider_policy::local_tool_turn_plan(
+                    effective_provider.as_ref(),
+                    &completion_options,
+                    prompt_tokens_for_plan,
+                    max_mutation_payload_bytes,
+                    base_completion_options.reasoning_effort.as_deref(),
+                    local_abs_max,
+                )
+            };
+            if let Some(ref plan) = local_tool_turn_plan {
+                crate::local_provider_policy::log_local_tool_turn_plan(plan);
+                if let Some(tx) = event_tx {
+                    let _ = tx.send(crate::StreamEvent::ActivityNotice(
+                        edgecrab_tools::tool_progress_tail::format_local_tool_turn_preflight(
+                            &plan.log_line(),
+                        ),
+                    ));
+                }
+            }
+
             let messages_for_api = if goal_block.is_empty() {
                 session.messages.clone()
             } else {
@@ -1879,37 +1917,6 @@ impl Agent {
                 effective_provider.as_ref(),
                 &app_config_ref,
             );
-            let base_completion_options = completion_options_for(&config);
-            let max_mutation_payload_bytes = app_config_ref.max_write_payload_bytes();
-            let completion_options = crate::local_provider_policy::effective_completion_options(
-                &base_completion_options,
-                effective_provider.as_ref(),
-                !active_tool_defs.is_empty(),
-                max_mutation_payload_bytes,
-            );
-            let prompt_tokens_for_plan = estimate_request_prompt_tokens(
-                session.cached_system_prompt.as_deref(),
-                &session.messages,
-                &active_tool_defs,
-            );
-            if !active_tool_defs.is_empty()
-                && let Some(plan) = crate::local_provider_policy::local_tool_turn_plan(
-                    effective_provider.as_ref(),
-                    &completion_options,
-                    prompt_tokens_for_plan,
-                    max_mutation_payload_bytes,
-                    base_completion_options.reasoning_effort.as_deref(),
-                )
-            {
-                crate::local_provider_policy::log_local_tool_turn_plan(&plan);
-                if let Some(tx) = event_tx {
-                    let _ = tx.send(crate::StreamEvent::ActivityNotice(
-                        edgecrab_tools::tool_progress_tail::format_local_tool_turn_preflight(
-                            &plan.log_line(),
-                        ),
-                    ));
-                }
-            }
 
             // API call with retry — sends tool definitions so LLM can request tool calls.
             // On failure, attempt the fallback provider if configured.
@@ -1929,10 +1936,19 @@ impl Agent {
                 event_tx.is_some(),
             ) && (!session.native_tool_streaming_disabled
                 || active_tool_defs.is_empty());
+            let local_turn_budget = local_tool_turn_plan
+                .as_ref()
+                .map(|plan| (plan.max_tool_argument_bytes, plan.max_tokens));
+            let api_tool_defs = edgecrab_tools::registry::annotate_llm_definitions_for_local_turn(
+                active_tool_defs.clone(),
+                effective_provider.name(),
+                local_turn_budget,
+            );
+
             let api_outcome = match api_call_with_retry(
                 &effective_provider,
                 &chat_messages,
-                &active_tool_defs,
+                &api_tool_defs,
                 MAX_RETRIES,
                 ApiCallContext {
                     options: Some(&completion_options),
@@ -2116,11 +2132,18 @@ impl Agent {
                                         fb_prov.as_ref(),
                                         !active_tool_defs.is_empty(),
                                         max_mutation_payload_bytes,
+                                        local_abs_max,
+                                    );
+                                let fb_tool_defs =
+                                    edgecrab_tools::registry::annotate_llm_definitions_for_local_turn(
+                                        active_tool_defs.clone(),
+                                        fb_prov.name(),
+                                        local_turn_budget,
                                     );
                                 match api_call_with_retry(
                                     &fb_prov,
                                     &chat_messages,
-                                    &active_tool_defs,
+                                    &fb_tool_defs,
                                     1,
                                     ApiCallContext {
                                         options: Some(&fb_completion_options),
@@ -3249,7 +3272,7 @@ fn format_preflight_tool_error(
     err: &ToolError,
 ) -> String {
     if matches!(err.core_error(), ToolError::InvalidArgs { .. })
-        && let Some(mut enriched) = reg.enrich_invalid_args_error(name, err)
+        && let Some(mut enriched) = reg.enrich_invalid_args_error(name, err, Some(args_json))
     {
         if enriched.suppression_key.is_none() {
             enriched.suppression_key = enriched
@@ -5833,7 +5856,7 @@ async fn dispatch_single_tool(
         Err(ref e) if matches!(e.core_error(), ToolError::InvalidArgs { .. }) => {
             // Enrich InvalidArgs with required_fields + usage_hint from schema.
             // This gives the LLM a precise corrective checklist on the next turn.
-            if let Some(mut enriched) = reg.enrich_invalid_args_error(name, e) {
+            if let Some(mut enriched) = reg.enrich_invalid_args_error(name, e, Some(&normalized_args_json)) {
                 if enriched.suppression_key.is_none()
                     && let Some(ref required_fields) = enriched.required_fields
                 {

--- a/crates/edgecrab-core/src/local_provider_policy.rs
+++ b/crates/edgecrab-core/src/local_provider_policy.rs
@@ -34,7 +34,18 @@ pub const LOCAL_PREFILL_CONTEXT_DIVISOR: usize = 8;
 /// Local mid-band structural compress threshold as a fraction of active context (no LLM).
 ///
 /// Fills the gap between preflight prune (~32k @ 262k) and LLM compress (50% ctx).
-pub const LOCAL_STRUCTURAL_COMPRESS_THRESHOLD_RATIO: f32 = 0.22;
+/// **0.20** (not 0.22): homelab agent.jsonl reports ~56–57k prompts @ 262k ctx; at 0.22
+/// the threshold is 57 671 — sessions at 57 000 never compress (deterministic gap).
+pub const LOCAL_STRUCTURAL_COMPRESS_THRESHOLD_RATIO: f32 = 0.20;
+
+/// Resolve mid-band structural compress ratio: env override > compile-time default.
+pub fn local_structural_compress_threshold_ratio() -> f32 {
+    std::env::var("EDGECRAB_LOCAL_STRUCTURAL_COMPRESS_RATIO")
+        .ok()
+        .and_then(|value| value.parse::<f32>().ok())
+        .filter(|ratio| *ratio > 0.0 && *ratio < 1.0)
+        .unwrap_or(LOCAL_STRUCTURAL_COMPRESS_THRESHOLD_RATIO)
+}
 
 /// Providers that run on localhost and queue generations server-side.
 pub fn is_local_inference_provider(provider_name: &str) -> bool {
@@ -151,23 +162,31 @@ pub fn local_http_timeout_secs(provider_name: &str) -> u64 {
     }
 }
 
-/// Absolute completion cap for local tool turns (env override for transport tuning).
-pub fn local_tool_turn_absolute_max_tokens() -> usize {
+/// Resolve absolute completion cap: env `EDGECRAB_LOCAL_TOOL_MAX_TOKENS` > config > compile-time default.
+pub fn local_tool_turn_absolute_max_tokens(config_value: usize) -> usize {
     std::env::var("EDGECRAB_LOCAL_TOOL_MAX_TOKENS")
         .ok()
         .and_then(|value| value.parse().ok())
-        .unwrap_or(edgecrab_tools::mutation_turn_policy::LOCAL_TOOL_TURN_ABS_MAX_TOKENS)
+        .unwrap_or(config_value)
+}
+
+/// Compile-time default when no session config is available (prompt assembly).
+pub fn local_tool_turn_absolute_max_tokens_default() -> usize {
+    local_tool_turn_absolute_max_tokens(
+        edgecrab_tools::mutation_turn_policy::LOCAL_TOOL_TURN_ABS_MAX_TOKENS,
+    )
 }
 
 /// Deterministic `max_tokens` for a local tool turn (DRY with pre-dispatch guards).
 pub fn local_tool_turn_max_tokens(
     provider: &dyn LLMProvider,
     max_mutation_payload_bytes: usize,
+    config_absolute_max: usize,
 ) -> usize {
     edgecrab_tools::mutation_turn_policy::output_token_budget_for_tool_turn(
         max_mutation_payload_bytes,
         provider,
-        local_tool_turn_absolute_max_tokens(),
+        local_tool_turn_absolute_max_tokens(config_absolute_max),
     )
 }
 
@@ -224,12 +243,14 @@ pub fn local_tool_turn_plan(
     prompt_tokens_estimated: usize,
     max_mutation_payload_bytes: usize,
     base_reasoning_effort: Option<&str>,
+    config_absolute_max: usize,
 ) -> Option<LocalToolTurnPlan> {
     if !is_local_inference_provider(provider.name()) {
         return None;
     }
+    let absolute = local_tool_turn_absolute_max_tokens(config_absolute_max);
     let max_tokens = options.max_tokens.unwrap_or_else(|| {
-        local_tool_turn_max_tokens(provider, max_mutation_payload_bytes)
+        local_tool_turn_max_tokens(provider, max_mutation_payload_bytes, config_absolute_max)
     });
     let reasoning_effort = options
         .reasoning_effort
@@ -243,7 +264,7 @@ pub fn local_tool_turn_plan(
         reasoning_effort,
         tool_choice_required: true,
         max_mutation_payload_bytes,
-        absolute_max_tokens: local_tool_turn_absolute_max_tokens(),
+        absolute_max_tokens: absolute,
         http_timeout_secs: local_http_timeout_secs(provider.name()),
         context_length: provider.max_context_length(),
         prompt_tokens_estimated,
@@ -261,11 +282,12 @@ pub fn effective_completion_options(
     provider: &dyn LLMProvider,
     has_tools: bool,
     max_mutation_payload_bytes: usize,
+    config_absolute_max: usize,
 ) -> CompletionOptions {
     if !has_tools || !is_local_inference_provider(provider.name()) {
         return base.clone();
     }
-    let cap = local_tool_turn_max_tokens(provider, max_mutation_payload_bytes);
+    let cap = local_tool_turn_max_tokens(provider, max_mutation_payload_bytes, config_absolute_max);
     let mut options = base.clone();
     options.max_tokens = Some(base.max_tokens.map(|tokens| tokens.min(cap)).unwrap_or(cap));
 
@@ -402,7 +424,7 @@ pub fn local_structural_compress_token_threshold(active_context_length: usize) -
     if active_context_length == 0 {
         return 0;
     }
-    (active_context_length as f32 * LOCAL_STRUCTURAL_COMPRESS_THRESHOLD_RATIO) as usize
+    (active_context_length as f32 * local_structural_compress_threshold_ratio()) as usize
 }
 
 /// Whether to run `compress_structural_only` on local tool turns (between prefill and LLM compress).
@@ -605,6 +627,16 @@ mod tests {
     }
 
     const TEST_MUTATION_BYTES: usize = 32 * 1024;
+    const TEST_ABS_MAX: usize = edgecrab_tools::mutation_turn_policy::LOCAL_TOOL_TURN_ABS_MAX_TOKENS;
+
+    #[test]
+    fn lh60_local_tool_turn_absolute_max_tokens_honors_config_before_default() {
+        let custom = 12_288;
+        assert_eq!(
+            super::local_tool_turn_absolute_max_tokens(custom),
+            custom
+        );
+    }
 
     #[test]
     fn local_provider_detection() {
@@ -668,10 +700,11 @@ mod tests {
             synced.as_ref(),
             true,
             TEST_MUTATION_BYTES,
+            TEST_ABS_MAX,
         );
         assert_eq!(
             capped.max_tokens,
-            Some(local_tool_turn_max_tokens(synced.as_ref(), TEST_MUTATION_BYTES))
+            Some(local_tool_turn_max_tokens(synced.as_ref(), TEST_MUTATION_BYTES, TEST_ABS_MAX))
         );
         assert_eq!(
             capped.reasoning_effort.as_deref(),
@@ -687,6 +720,7 @@ mod tests {
             synced.as_ref(),
             true,
             TEST_MUTATION_BYTES,
+            TEST_ABS_MAX,
         );
         assert_eq!(kept.max_tokens, Some(512));
         assert_eq!(
@@ -694,7 +728,7 @@ mod tests {
             Some(LOCAL_TOOL_TURN_REASONING_EFFORT)
         );
 
-        let plain = effective_completion_options(&base, synced.as_ref(), false, TEST_MUTATION_BYTES);
+        let plain = effective_completion_options(&base, synced.as_ref(), false, TEST_MUTATION_BYTES, TEST_ABS_MAX);
         assert_eq!(plain.max_tokens, Some(16_384));
         assert_eq!(plain.reasoning_effort.as_deref(), Some("high"));
     }
@@ -711,6 +745,7 @@ mod tests {
             provider.as_ref(),
             true,
             TEST_MUTATION_BYTES,
+            TEST_ABS_MAX,
         );
         assert_eq!(
             options.reasoning_effort.as_deref(),
@@ -722,6 +757,7 @@ mod tests {
             50_000,
             TEST_MUTATION_BYTES,
             Some("none"),
+            TEST_ABS_MAX,
         )
         .expect("plan");
         assert!(!plan.reasoning_overridden);
@@ -740,6 +776,7 @@ mod tests {
             provider.as_ref(),
             true,
             TEST_MUTATION_BYTES,
+            TEST_ABS_MAX,
         );
         let plan = local_tool_turn_plan(
             provider.as_ref(),
@@ -747,6 +784,7 @@ mod tests {
             50_000,
             TEST_MUTATION_BYTES,
             Some("high"),
+            TEST_ABS_MAX,
         )
         .expect("plan");
         assert!(plan.reasoning_overridden);
@@ -760,6 +798,7 @@ mod tests {
             provider.as_ref(),
             true,
             TEST_MUTATION_BYTES,
+            TEST_ABS_MAX,
         );
         let plan = local_tool_turn_plan(
             provider.as_ref(),
@@ -767,11 +806,12 @@ mod tests {
             50_000,
             TEST_MUTATION_BYTES,
             None,
+            TEST_ABS_MAX,
         )
         .expect("plan");
         assert_eq!(
             plan.max_tokens,
-            local_tool_turn_max_tokens(provider.as_ref(), TEST_MUTATION_BYTES)
+            local_tool_turn_max_tokens(provider.as_ref(), TEST_MUTATION_BYTES, TEST_ABS_MAX)
         );
         assert_eq!(plan.context_length, 262_144);
         assert_eq!(plan.http_timeout_secs, DEFAULT_LOCAL_HTTP_TIMEOUT_SECS);
@@ -903,7 +943,7 @@ mod tests {
     fn should_local_structural_compress_mid_band_only() {
         let ctx = 262_144;
         let mid = local_structural_compress_token_threshold(ctx);
-        assert_eq!(mid, 57_671);
+        assert_eq!(mid, 52_428);
         let llm = (ctx as f32 * 0.5) as usize;
         assert!(should_local_structural_compress(58_000, ctx, llm));
         assert!(!should_local_structural_compress(40_000, ctx, llm));
@@ -918,6 +958,7 @@ mod tests {
             provider.as_ref(),
             true,
             TEST_MUTATION_BYTES,
+            TEST_ABS_MAX,
         );
         let plan = local_tool_turn_plan(
             provider.as_ref(),
@@ -925,6 +966,7 @@ mod tests {
             50_000,
             TEST_MUTATION_BYTES,
             None,
+            TEST_ABS_MAX,
         )
         .expect("plan");
         let expected = edgecrab_tools::mutation_turn_policy::max_tool_argument_bytes(

--- a/crates/edgecrab-core/src/prompt_builder.rs
+++ b/crates/edgecrab-core/src/prompt_builder.rs
@@ -631,6 +631,24 @@ fn code_editing_guidance() -> String {
     edgecrab_tools::mutation_turn_policy::default_code_editing_guidance()
 }
 
+fn code_editing_guidance_for_model(model_str: &str) -> String {
+    let provider = model_str.split('/').next().unwrap_or(model_str);
+    if matches!(provider, "lmstudio" | "ollama") {
+        let max_bytes = edgecrab_tools::mutation_turn_policy::local_default_max_tool_argument_bytes();
+        let max_kib = max_bytes.div_ceil(1024);
+        edgecrab_tools::mutation_turn_policy::code_editing_guidance(max_bytes, max_kib)
+    } else {
+        code_editing_guidance()
+    }
+}
+
+fn is_local_inference_model(model_str: &str) -> bool {
+    matches!(
+        model_str.split('/').next().unwrap_or(model_str),
+        "lmstudio" | "ollama"
+    )
+}
+
 const SKILLS_GUIDANCE: &str = "\
 After completing a complex task (5+ tool calls), fixing a tricky error, or discovering \
 a non-trivial workflow, save the approach as a skill with skill_manage so you can reuse \
@@ -1249,7 +1267,7 @@ impl PromptBuilder {
 
         // 14. Direct code-editing guidance — only when file-mutation tools are present.
         if self.has_any_tool(&["apply_patch", "write_file"]) {
-            stable.push(Cow::Owned(code_editing_guidance()));
+            stable.push(Cow::Owned(code_editing_guidance_for_model(model_str)));
         }
 
         // 15a. File-output enforcement guidance (FP34) — injected whenever write_file
@@ -1304,6 +1322,22 @@ impl PromptBuilder {
                 }
             }
             dynamic.push(Cow::Owned(ts));
+        }
+
+        // D1b. Local inference output geometry — dynamic because model/provider is session config.
+        if is_local_inference_model(model_str)
+            && self.has_any_tool(&["write_file", "patch", "apply_patch", "execute_code"])
+        {
+            let max_tokens = crate::local_provider_policy::local_tool_turn_absolute_max_tokens_default();
+            let max_arg =
+                edgecrab_tools::mutation_turn_policy::local_max_tool_argument_bytes_for_output_tokens(
+                    max_tokens,
+                );
+            dynamic.push(Cow::Owned(
+                edgecrab_tools::mutation_turn_policy::local_inference_geometry_guidance(
+                    max_arg, max_tokens,
+                ),
+            ));
         }
 
         // D2. Execution environment guidance (cwd, allowed paths, etc.)
@@ -3304,6 +3338,36 @@ Run `${CLAUDE_SKILL_DIR}/scripts/helper.py --session ${CLAUDE_SESSION_ID}`.\n",
         assert!(
             !prompt.contains("## Code Editing Execution"),
             "code-editing guidance must not appear without mutation tools"
+        );
+    }
+
+    #[test]
+    fn lh55_local_model_code_editing_guidance_uses_output_geometry_not_config_kib() {
+        let builder = PromptBuilder::new(Platform::Cli)
+            .skip_context_files(true)
+            .model_name(Some("lmstudio/qwen/qwen3.6-35b-a3b".into()))
+            .available_tools(vec![
+                "write_file".to_string(),
+                "patch".to_string(),
+                "execute_code".to_string(),
+            ]);
+        let blocks = builder.build_blocks(None, None, &[], None);
+        let combined = blocks.combined();
+        assert!(
+            combined.contains("27852 bytes"),
+            "local model must cite output-geometry arg cap, not 32 KiB config limit"
+        );
+        assert!(
+            !combined.contains("32768 bytes (32 KiB)"),
+            "local model must not cite cloud config cap in code-editing guidance"
+        );
+        assert!(
+            combined.contains("## Local Inference Tool Geometry"),
+            "local model must include dynamic geometry block"
+        );
+        assert!(
+            combined.contains("max completion tokens: 8192"),
+            "geometry block must cite local max_tokens default"
         );
     }
 

--- a/crates/edgecrab-core/tests/local_harness_geometry_e2e.rs
+++ b/crates/edgecrab-core/tests/local_harness_geometry_e2e.rs
@@ -1,0 +1,271 @@
+//! End-to-end geometry + schema gates for the local inference harness (P6/P7/P8).
+//!
+//! Cross-crate wiring: config → policy → mutation budget → tool schema annotation.
+//! Deterministic fixtures only — no live LM Studio server.
+
+use std::sync::Arc;
+
+use edgecrab_core::local_provider_policy::{
+    effective_completion_options, local_tool_turn_absolute_max_tokens,
+    local_tool_turn_plan, LocalToolTurnPlan,
+};
+use edgecrab_tools::{AppConfigRef, ToolContext, ToolRegistry};
+use edgecrab_tools::mutation_turn_policy::{
+    local_default_max_tool_argument_bytes, local_max_tool_argument_bytes_for_output_tokens,
+    LOCAL_TOOL_TURN_ABS_MAX_TOKENS,
+};
+use edgecrab_tools::registry::{annotate_llm_definitions_for_local_turn, to_llm_definitions};
+use edgecrab_types::{Platform, ToolError};
+use edgequake_llm::{CompletionOptions, LLMProvider};
+use tokio_util::sync::CancellationToken;
+
+const LMSTUDIO_SYNCED_CTX: usize = 262_144;
+
+fn minimal_tool_ctx() -> ToolContext {
+    ToolContext {
+        task_id: "lh-e2e".into(),
+        cwd: std::env::temp_dir(),
+        session_id: "lh-e2e-session".into(),
+        user_task: None,
+        cancel: CancellationToken::new(),
+        config: AppConfigRef::default(),
+        state_db: None,
+        platform: Platform::Cli,
+        process_table: None,
+        provider: None,
+        tool_registry: None,
+        delegate_depth: 0,
+        delegate_agent_id: None,
+        delegate_parent_id: None,
+        sub_agent_runner: None,
+        delegation_event_tx: None,
+        clarify_tx: None,
+        approval_tx: None,
+        on_skills_changed: None,
+        gateway_sender: None,
+        origin_chat: None,
+        session_key: None,
+        todo_store: None,
+        current_tool_call_id: None,
+        current_tool_name: None,
+        injected_messages: None,
+        tool_progress_tx: None,
+        watch_notification_tx: None,
+        mutation_turn: None,
+        lsp_gate: None,
+        kanban_task_id: None,
+    }
+}
+
+struct NamedProvider {
+    name: &'static str,
+    context_length: usize,
+    default_output: Option<usize>,
+}
+
+impl NamedProvider {
+    fn lmstudio(context_length: usize, default_output: Option<usize>) -> Self {
+        Self {
+            name: "lmstudio",
+            context_length,
+            default_output,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl LLMProvider for NamedProvider {
+    fn name(&self) -> &str {
+        self.name
+    }
+
+    fn model(&self) -> &str {
+        "qwen/qwen3.6-35b-a3b"
+    }
+
+    fn max_context_length(&self) -> usize {
+        self.context_length
+    }
+
+    fn default_max_output_tokens(&self) -> Option<usize> {
+        self.default_output
+    }
+
+    async fn complete(
+        &self,
+        prompt: &str,
+    ) -> edgequake_llm::Result<edgequake_llm::LLMResponse> {
+        Ok(edgequake_llm::LLMResponse::new(prompt, self.model()))
+    }
+
+    async fn complete_with_options(
+        &self,
+        prompt: &str,
+        _options: &CompletionOptions,
+    ) -> edgequake_llm::Result<edgequake_llm::LLMResponse> {
+        self.complete(prompt).await
+    }
+
+    async fn chat(
+        &self,
+        _messages: &[edgequake_llm::ChatMessage],
+        _options: Option<&CompletionOptions>,
+    ) -> edgequake_llm::Result<edgequake_llm::LLMResponse> {
+        Ok(edgequake_llm::LLMResponse::new("", self.model()))
+    }
+}
+
+/// **LH-60** — config `max_tool_turn_tokens` resolves before compile-time default (8192).
+#[test]
+fn lh60_e2e_config_max_tokens_and_arg_geometry_chain() {
+    assert_eq!(LOCAL_TOOL_TURN_ABS_MAX_TOKENS, 8192);
+    assert_eq!(
+        local_tool_turn_absolute_max_tokens(4096),
+        4096,
+        "yaml config value wins when env unset"
+    );
+    assert_eq!(
+        local_default_max_tool_argument_bytes(),
+        local_max_tool_argument_bytes_for_output_tokens(8192)
+    );
+    assert_eq!(local_default_max_tool_argument_bytes(), 27_852);
+}
+
+/// **LH-60b** — conversation shelf plan line cites live max_arg from geometry chain.
+#[test]
+fn lh60b_e2e_local_tool_turn_plan_geometry_matches_policy() {
+    let provider: Arc<dyn LLMProvider> =
+        Arc::new(NamedProvider::lmstudio(LMSTUDIO_SYNCED_CTX, Some(8192)));
+    let config_abs_max = local_tool_turn_absolute_max_tokens(8192);
+    let options = effective_completion_options(
+        &CompletionOptions::default(),
+        provider.as_ref(),
+        true,
+        32 * 1024,
+        config_abs_max,
+    );
+    let plan = local_tool_turn_plan(
+        provider.as_ref(),
+        &options,
+        57_000,
+        32 * 1024,
+        None,
+        config_abs_max,
+    )
+    .expect("plan");
+
+    assert_eq!(plan.max_tokens, 8192);
+    assert_eq!(plan.max_tool_argument_bytes, 27_852);
+    assert!(plan.log_line().contains("max_tokens=8192"));
+    assert!(plan.log_line().contains("max_arg=27852B"));
+    assert_eq!(plan.prompt_tokens_estimated, 57_000);
+}
+
+/// **LH-61** — registry → annotate path appends live budget to mutation tools only.
+#[test]
+fn lh61_e2e_registry_definitions_annotated_for_local_turn() {
+    let registry = ToolRegistry::new();
+    let ctx = minimal_tool_ctx();
+    let schemas = registry.get_definitions(None, None, &ctx);
+    let defs = to_llm_definitions(&schemas);
+
+    let write_def = defs
+        .iter()
+        .find(|d| d.function.name == "write_file")
+        .expect("write_file in core toolset");
+    assert!(
+        !write_def.function.description.contains("Local turn limit"),
+        "baseline schema must not embed budget"
+    );
+
+    let annotated = annotate_llm_definitions_for_local_turn(
+        defs,
+        "lmstudio",
+        Some((27_852, 8192)),
+    );
+    let write_annotated = annotated
+        .iter()
+        .find(|d| d.function.name == "write_file")
+        .expect("write_file");
+    assert!(write_annotated.function.description.contains("27852"));
+    assert!(write_annotated.function.description.contains("8192"));
+
+    let read_annotated = annotated
+        .iter()
+        .find(|d| d.function.name == "read_file")
+        .expect("read_file");
+    assert!(
+        !read_annotated.function.description.contains("Local turn limit"),
+        "non-mutation tools unchanged"
+    );
+}
+
+/// **LH-62** — patch flat object schema + invalid-args enrichment respects `mode`.
+#[test]
+fn lh62_e2e_patch_flat_schema_invalid_args_enrichment_by_mode() {
+    let registry = ToolRegistry::new();
+    let ctx = minimal_tool_ctx();
+    let patch_schema = registry
+        .get_definitions(None, None, &ctx)
+        .into_iter()
+        .find(|s| s.name == "patch")
+        .expect("patch tool registered");
+    assert!(
+        patch_schema.parameters.get("oneOf").is_none(),
+        "P6 flat object schema for LM Studio"
+    );
+    assert_eq!(
+        patch_schema.parameters.get("type").and_then(|v| v.as_str()),
+        Some("object")
+    );
+    let replace_args = r#"{"mode":"replace","path":"tmp/outline.md"}"#;
+    let replace_err = ToolError::InvalidArgs {
+        tool: "patch".into(),
+        message: "missing field `old_string`".into(),
+    };
+    let replace_payload = registry
+        .enrich_invalid_args_error("patch", &replace_err, Some(replace_args))
+        .expect("enriched");
+    let replace_fields = replace_payload.required_fields.as_ref().expect("fields");
+    assert!(replace_fields.iter().any(|f| f == "old_string"));
+    assert!(replace_fields.iter().any(|f| f == "new_string"));
+
+    let patch_args = r#"{"mode":"patch","path":"tmp/outline.md"}"#;
+    let patch_err = ToolError::InvalidArgs {
+        tool: "patch".into(),
+        message: "missing field `patch`".into(),
+    };
+    let patch_payload = registry
+        .enrich_invalid_args_error("patch", &patch_err, Some(patch_args))
+        .expect("enriched");
+    let patch_fields = patch_payload.required_fields.as_ref().expect("fields");
+    assert!(patch_fields.iter().any(|f| f == "patch"));
+    assert!(
+        !patch_fields.iter().any(|f| f == "old_string"),
+        "patch branch must not require replace-only fields"
+    );
+}
+
+/// **LH-62b** — shelf plan type exposes geometry fields used by conversation preflight.
+#[test]
+fn lh62b_e2e_local_tool_turn_plan_fields_are_stable() {
+    let plan = LocalToolTurnPlan {
+        provider: "lmstudio".into(),
+        model: "qwen".into(),
+        max_tokens: 8192,
+        reasoning_effort: "none".into(),
+        reasoning_overridden: true,
+        tool_choice_required: true,
+        max_mutation_payload_bytes: 32 * 1024,
+        absolute_max_tokens: 8192,
+        http_timeout_secs: 600,
+        context_length: LMSTUDIO_SYNCED_CTX,
+        prompt_tokens_estimated: 57_000,
+        max_tool_argument_bytes: 27_852,
+        non_streaming: true,
+    };
+    let line = plan.log_line();
+    assert!(line.contains("tool_choice=required"));
+    assert!(line.contains("non-streaming"));
+    assert!(line.contains("~57k/262k"));
+}

--- a/crates/edgecrab-core/tests/local_prefill_prune_e2e.rs
+++ b/crates/edgecrab-core/tests/local_prefill_prune_e2e.rs
@@ -183,7 +183,7 @@ fn lh11_length_recovery_prune_drops_tokens_in_mid_band() {
     assert_eq!(direct_outcome.tools_pruned, outcome.tools_pruned);
 }
 
-/// High-band fixture: ~57k+ tokens, above 22% structural compress, below 50% LLM compress.
+/// High-band fixture: ~57k+ tokens, above 20% structural compress, below 50% LLM compress.
 const HIGH_BAND_TOOL_ROUNDS: usize = 12;
 const HIGH_BAND_BODY_CHARS: usize = 20_000;
 
@@ -263,4 +263,36 @@ fn lh33_local_structural_compress_reduces_high_band_tokens() {
     assert_eq!(tokens_before, before);
     assert!(tokens_after < tokens_before / 2);
     assert!(compressed.len() < messages.len());
+}
+
+/// **LH-63** — homelab ~57k signature must exceed 20% mid-band threshold (was gap @ 0.22).
+#[test]
+fn lh63_homelab_57k_band_triggers_structural_compress_at_20pct() {
+    use edgecrab_core::local_provider_policy::{
+        local_structural_compress_token_threshold, should_local_structural_compress,
+    };
+
+    let messages = high_band_messages();
+    let before = estimate_tokens(&messages);
+    let mid = local_structural_compress_token_threshold(LMSTUDIO_SYNCED_CTX);
+
+    assert_eq!(mid, 52_428, "262144 × 0.20");
+    assert!(
+        before > mid,
+        "fixture must exceed mid-band threshold (before={before} mid={mid})"
+    );
+    assert!(
+        57_000 > mid,
+        "homelab-reported ~57k must exceed 20% threshold (mid={mid})"
+    );
+    assert!(should_local_structural_compress(
+        before,
+        LMSTUDIO_SYNCED_CTX,
+        COMPRESSION_THRESHOLD_AT_50PCT,
+    ));
+    assert!(should_local_structural_compress(
+        57_000,
+        LMSTUDIO_SYNCED_CTX,
+        COMPRESSION_THRESHOLD_AT_50PCT,
+    ));
 }

--- a/crates/edgecrab-proxy/src/backend/auth_file.rs
+++ b/crates/edgecrab-proxy/src/backend/auth_file.rs
@@ -10,15 +10,40 @@ use crate::error::ProxyError;
 use super::auth_lock::with_auth_store_lock;
 use super::auth_store::provider_state_from_doc;
 
-/// Default auth store: `~/.edgecrab/auth.json`, else `~/.hermes/auth.json`.
+/// Default auth store: `~/.edgecrab/auth.json` (created by `edgecrab auth add`).
 pub fn default_auth_path() -> PathBuf {
-    let edgecrab = edgecrab_home().join("auth.json");
-    if edgecrab.exists() {
+    edgecrab_home().join("auth.json")
+}
+
+fn hermes_auth_path() -> Option<PathBuf> {
+    dirs::home_dir().map(|h| h.join(".hermes").join("auth.json"))
+}
+
+fn doc_has_provider(doc: &Value, provider: &str) -> bool {
+    if super::auth_store::provider_state_from_doc(doc, provider).is_some() {
+        return true;
+    }
+    !read_credential_pool_entries(doc, provider).is_empty()
+}
+
+/// Resolve which auth.json holds `provider` — EdgeCrab first, Hermes only when populated.
+pub fn auth_path_for_provider(provider: &str) -> PathBuf {
+    let edgecrab = default_auth_path();
+    if edgecrab.is_file()
+        && load_auth_doc(&edgecrab)
+            .ok()
+            .is_some_and(|doc| doc_has_provider(&doc, provider))
+    {
         return edgecrab;
     }
-    dirs::home_dir()
-        .map(|h| h.join(".hermes").join("auth.json"))
-        .unwrap_or(edgecrab)
+    if let Some(hermes) = hermes_auth_path().filter(|p| p.is_file())
+        && load_auth_doc(&hermes)
+            .ok()
+            .is_some_and(|doc| doc_has_provider(&doc, provider))
+    {
+        return hermes;
+    }
+    edgecrab
 }
 
 pub fn load_auth_doc(path: &Path) -> Result<Value, ProxyError> {
@@ -174,5 +199,49 @@ mod tests {
         let (b2, _) =
             bearer_and_base_from_entry(&state, "https://fallback/v1").expect("state bearer");
         assert_eq!(b2, "singleton-tok");
+    }
+
+    #[test]
+    fn auth_path_for_provider_prefers_edgecrab_when_both_have_provider() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let ec = dir.path().join("edgecrab");
+        let hermes_dir = dir.path().join(".hermes");
+        std::fs::create_dir_all(&ec).expect("mkdir ec");
+        std::fs::create_dir_all(&hermes_dir).expect("mkdir hermes");
+        let doc = serde_json::json!({
+            "providers": {
+                "xai-oauth": { "tokens": { "access_token": "tok" } }
+            }
+        });
+        std::fs::write(ec.join("auth.json"), doc.to_string()).expect("write ec");
+        std::fs::write(hermes_dir.join("auth.json"), doc.to_string()).expect("write hm");
+        // SAFETY: test-only env isolation.
+        unsafe {
+            std::env::set_var("EDGECRAB_HOME", ec.to_str().expect("utf8"));
+            std::env::set_var("HOME", dir.path().to_str().expect("utf8"));
+        }
+        assert_eq!(
+            auth_path_for_provider("xai-oauth"),
+            ec.join("auth.json")
+        );
+    }
+
+    #[test]
+    fn auth_path_for_provider_returns_edgecrab_when_neither_has_provider() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let ec = dir.path().join("edgecrab");
+        let hermes_dir = dir.path().join(".hermes");
+        std::fs::create_dir_all(&ec).expect("mkdir ec");
+        std::fs::create_dir_all(&hermes_dir).expect("mkdir hermes");
+        std::fs::write(hermes_dir.join("auth.json"), r#"{"providers":{}}"#).expect("write hm");
+        // SAFETY: test-only env isolation.
+        unsafe {
+            std::env::set_var("EDGECRAB_HOME", ec.to_str().expect("utf8"));
+            std::env::set_var("HOME", dir.path().to_str().expect("utf8"));
+        }
+        assert_eq!(
+            auth_path_for_provider("xai-oauth"),
+            ec.join("auth.json")
+        );
     }
 }

--- a/crates/edgecrab-proxy/src/lib.rs
+++ b/crates/edgecrab-proxy/src/lib.rs
@@ -32,7 +32,7 @@ pub mod e2e_harness;
 
 pub use auth::{ensure_proxy_token, load_proxy_token, write_proxy_token};
 pub use backend::adapter::describe_adapter;
-pub use backend::auth_file::{default_auth_path, remove_provider_state};
+pub use backend::auth_file::{auth_path_for_provider, default_auth_path, remove_provider_state};
 pub use backend::nous::state_requires_relogin;
 pub use backend::nous::{
     DEFAULT_NOUS_INFERENCE, NousDeviceLoginOptions, login_nous_portal, persist_nous_oauth,

--- a/crates/edgecrab-tools/src/config_ref.rs
+++ b/crates/edgecrab-tools/src/config_ref.rs
@@ -296,6 +296,8 @@ pub struct AppConfigRef {
     pub max_write_payload_kib: usize,
     /// Default `write_file` create_dirs when the model omits the flag.
     pub local_write_create_dirs: bool,
+    /// Absolute completion cap for local tool turns (yaml default; env overrides).
+    pub local_max_tool_turn_tokens: usize,
     /// Pluggable web search backend chain configuration.
     pub web_search: WebSearchConfigRef,
     /// Hermes-aligned web tool backend overrides (`web:` in config.yaml).
@@ -382,6 +384,8 @@ impl Default for AppConfigRef {
             result_turn_budget_chars: 200_000,
             max_write_payload_kib: crate::edit_contract::DEFAULT_MAX_MUTATION_PAYLOAD_KIB,
             local_write_create_dirs: true,
+            local_max_tool_turn_tokens:
+                crate::mutation_turn_policy::LOCAL_TOOL_TURN_ABS_MAX_TOKENS,
             web_search: WebSearchConfigRef::default(),
             web: WebToolsConfigRef::default(),
         }

--- a/crates/edgecrab-tools/src/mutation_turn_policy.rs
+++ b/crates/edgecrab-tools/src/mutation_turn_policy.rs
@@ -20,10 +20,23 @@ pub const TOOL_ARG_BUDGET_SAFETY_RATIO: f32 = 0.85;
 /// Minimum argument budget — below this, incremental edits are impractical.
 pub const MIN_TOOL_ARGUMENT_BYTES: usize = 1024;
 
-/// Hard transport-bound for one local tool-turn completion (seconds-scale HTTP window).
+/// Default completion cap for one local tool turn (deterministic; not failure-adaptive).
 ///
-/// Overridable at runtime via `EDGECRAB_LOCAL_TOOL_MAX_TOKENS` in edgecrab-core.
-pub const LOCAL_TOOL_TURN_ABS_MAX_TOKENS: usize = 2048;
+/// 8192 tokens → ~27 KiB max tool-argument bytes (enough for typical single-file scaffolds).
+/// Override at runtime via `EDGECRAB_LOCAL_TOOL_MAX_TOKENS` in edgecrab-core.
+pub const LOCAL_TOOL_TURN_ABS_MAX_TOKENS: usize = 8192;
+
+/// Max tool-argument bytes derivable from a fixed output-token budget (geometry formula).
+pub fn local_max_tool_argument_bytes_for_output_tokens(output_tokens: usize) -> usize {
+    let completion_cap = ((output_tokens * TOOL_ARG_CHARS_PER_TOKEN) as f32
+        * TOOL_ARG_BUDGET_SAFETY_RATIO) as usize;
+    DEFAULT_MAX_MUTATION_PAYLOAD_BYTES.min(completion_cap.max(MIN_TOOL_ARGUMENT_BYTES))
+}
+
+/// Default max tool-argument bytes when no live `LLMProvider` is available (prompt assembly).
+pub fn local_default_max_tool_argument_bytes() -> usize {
+    local_max_tool_argument_bytes_for_output_tokens(LOCAL_TOOL_TURN_ABS_MAX_TOKENS)
+}
 
 /// Fixed JSON envelope overhead (`id`, `name`, escaping) atop argument tokens.
 const TOOL_CALL_ENVELOPE_TOKENS: usize = 64;
@@ -183,11 +196,39 @@ pub fn length_without_tools_recovery_message(
     let hint = tool_turn_budget_hint(max_mutation_payload_bytes, provider);
     format!(
         "[System: Your previous completion hit max_tokens (finish_reason=length) without \
-         emitting tool_calls. The output budget (~{} completion tokens) cannot fit a large \
-         monolithic tool argument (max {} bytes). Do NOT retry the same oversized call. \
-         Use incremental edits: (1) minimal write_file scaffold (≤{} KiB), \
-         (2) extend with patch/apply_patch. Each tool call must stay under {} bytes.]",
+         emitting tool_calls. The output budget (~{} completion tokens, max {} bytes per tool \
+         argument) cannot fit a large monolithic tool payload. Do NOT retry the same oversized \
+         call. Use incremental edits: (1) minimal write_file scaffold (≤{} KiB), (2) extend with \
+         patch/apply_patch. Each tool call must stay under {} bytes.]",
         hint.output_budget, hint.max_bytes, hint.max_kib, hint.max_bytes
+    )
+}
+
+/// Suffix appended to mutation-tool descriptions on local provider tool turns.
+pub fn local_tool_budget_schema_suffix(max_arg_bytes: usize, max_output_tokens: usize) -> String {
+    format!(
+        " Local turn limit: max argument ~{max_arg_bytes} bytes (~{max_output_tokens} completion tokens)."
+    )
+}
+
+/// Stable dynamic-zone block: local provider output geometry (Layer 2).
+///
+/// WHY separate from cloud `code_editing_guidance`: cloud stable prompt cites the 32 KiB config
+/// cap; local tool turns share one completion bounded by `max_output_tokens` × chars/token × safety.
+pub fn local_inference_geometry_guidance(max_arg_bytes: usize, max_output_tokens: usize) -> String {
+    let max_kib = max_arg_bytes.div_ceil(1024);
+    format!(
+        "\
+## Local Inference Tool Geometry (binding)
+
+You are on a local provider (LM Studio / Ollama). Each tool turn has a hard output ceiling:
+  - max completion tokens: {max_output_tokens}
+  - max tool-argument size: {max_arg_bytes} bytes (~{max_kib} KiB)
+
+Rules:
+  - A tool-call argument must fit in one completion — oversized write_file / execute_code payloads \
+will hit max_tokens without parseable tool_calls.
+  - For artifacts larger than ~{max_kib} KiB: minimal write_file scaffold, then patch/apply_patch chunks."
     )
 }
 
@@ -450,7 +491,27 @@ mod tests {
         assert!(msg.contains("finish_reason=length"));
         assert!(msg.contains("without emitting tool_calls"));
         assert!(msg.contains(&max_bytes.to_string()));
+        assert!(msg.contains("scaffold"));
         assert!(!msg.contains("interrupted"));
         assert!(!msg.contains("draft was interrupted"));
+        assert!(!msg.contains("manage_todo_list"));
+    }
+
+    #[test]
+    fn lh52_local_default_max_tool_argument_bytes_matches_abs_max_geometry() {
+        assert_eq!(
+            local_default_max_tool_argument_bytes(),
+            local_max_tool_argument_bytes_for_output_tokens(LOCAL_TOOL_TURN_ABS_MAX_TOKENS)
+        );
+        assert_eq!(local_default_max_tool_argument_bytes(), 27_852);
+    }
+
+    #[test]
+    fn lh54_local_inference_geometry_guidance_cites_arg_cap_not_config_kib() {
+        let block = local_inference_geometry_guidance(27_852, LOCAL_TOOL_TURN_ABS_MAX_TOKENS);
+        assert!(block.contains("27852"));
+        assert!(block.contains("8192"));
+        assert!(!block.contains("32768"));
+        assert!(!block.contains("manage_todo_list"));
     }
 }

--- a/crates/edgecrab-tools/src/registry.rs
+++ b/crates/edgecrab-tools/src/registry.rs
@@ -929,6 +929,7 @@ impl ToolRegistry {
         &self,
         tool_name: &str,
         error: &ToolError,
+        args_json: Option<&str>,
     ) -> Option<edgecrab_types::ToolErrorResponse> {
         if !matches!(error.core_error(), ToolError::InvalidArgs { .. }) {
             return None;
@@ -942,15 +943,8 @@ impl ToolRegistry {
         };
 
         let schema = handler.schema();
-        let required_fields = schema
-            .parameters
-            .get("required")
-            .and_then(|v| v.as_array())
-            .map(|arr| {
-                arr.iter()
-                    .filter_map(|v| v.as_str().map(String::from))
-                    .collect::<Vec<_>>()
-            });
+        let required_fields =
+            required_fields_from_parameters(&schema.parameters, args_json);
 
         let usage_hint = Self::build_usage_hint(&schema);
 
@@ -1077,16 +1071,7 @@ impl ToolRegistry {
         };
 
         Some(
-            schema
-                .parameters
-                .get("required")
-                .and_then(|v| v.as_array())
-                .map(|arr| {
-                    arr.iter()
-                        .filter_map(|v| v.as_str().map(String::from))
-                        .collect::<Vec<_>>()
-                })
-                .unwrap_or_default(),
+            required_fields_from_parameters(&schema.parameters, None).unwrap_or_default(),
         )
     }
 
@@ -1266,10 +1251,150 @@ pub fn to_llm_definitions(schemas: &[ToolSchema]) -> Vec<edgequake_llm::ToolDefi
             edgequake_llm::ToolDefinition::function(
                 &s.name,
                 &s.description,
-                normalize_json_schema(&s.parameters),
+                openai_compatible_tool_parameters(&s.parameters),
             )
         })
         .collect()
+}
+
+/// OpenAI-compatible wire shape: top-level `type: "object"` only (LM Studio rejects `oneOf`).
+pub fn openai_compatible_tool_parameters(schema: &Value) -> Value {
+    if let Some(one_of) = schema.get("oneOf").and_then(Value::as_array) {
+        return flatten_oneof_object_schema(one_of);
+    }
+    normalize_json_schema(schema)
+}
+
+fn flatten_oneof_object_schema(branches: &[Value]) -> Value {
+    let mut properties = Map::new();
+    for branch in branches {
+        if let Some(props) = branch.get("properties").and_then(Value::as_object) {
+            for (key, value) in props {
+                properties.entry(key.clone()).or_insert_with(|| value.clone());
+            }
+        }
+    }
+    Value::Object(Map::from_iter([
+        ("type".into(), Value::String("object".into())),
+        ("additionalProperties".into(), Value::Bool(false)),
+        ("properties".into(), Value::Object(properties)),
+        (
+            "required".into(),
+            Value::Array(vec![Value::String("mode".into())]),
+        ),
+    ]))
+}
+
+/// Append live output-geometry limits to mutation-tool descriptions (local providers only).
+pub fn annotate_llm_definitions_for_local_turn(
+    defs: Vec<edgequake_llm::ToolDefinition>,
+    provider_name: &str,
+    local_turn_budget: Option<(usize, usize)>,
+) -> Vec<edgequake_llm::ToolDefinition> {
+    let Some((max_arg_bytes, max_output_tokens)) = local_turn_budget else {
+        return defs;
+    };
+    if !matches!(provider_name, "lmstudio" | "ollama") {
+        return defs;
+    }
+    let suffix =
+        crate::mutation_turn_policy::local_tool_budget_schema_suffix(max_arg_bytes, max_output_tokens);
+    defs.into_iter()
+        .map(|mut def| {
+            if crate::mutation_turn_policy::is_large_payload_tool(&def.function.name) {
+                def.function.description.push_str(&suffix);
+            }
+            def
+        })
+        .collect()
+}
+
+fn patch_mode_required_fields(mode: &str) -> Vec<String> {
+    match mode {
+        "patch" => vec![
+            "mode".into(),
+            "patch".into(),
+        ],
+        _ => vec![
+            "mode".into(),
+            "path".into(),
+            "old_string".into(),
+            "new_string".into(),
+        ],
+    }
+}
+
+fn is_patch_flat_schema(parameters: &Value) -> bool {
+    parameters.get("type").and_then(Value::as_str) == Some("object")
+        && parameters
+            .get("properties")
+            .and_then(|p| p.get("mode"))
+            .and_then(|m| m.get("enum"))
+            .is_some()
+        && parameters
+            .get("properties")
+            .and_then(|p| p.get("patch"))
+            .is_some()
+        && parameters
+            .get("properties")
+            .and_then(|p| p.get("old_string"))
+            .is_some()
+}
+
+fn required_fields_from_parameters(
+    parameters: &Value,
+    args_json: Option<&str>,
+) -> Option<Vec<String>> {
+    if let Some(one_of) = parameters.get("oneOf").and_then(Value::as_array) {
+        let mode = args_json
+            .and_then(|raw| serde_json::from_str::<Value>(raw).ok())
+            .and_then(|v| v.get("mode").and_then(Value::as_str).map(String::from))
+            .unwrap_or_else(|| "replace".to_string());
+        for branch in one_of {
+            let branch_mode = branch
+                .get("properties")
+                .and_then(|p| p.get("mode"))
+                .and_then(|m| m.get("const"))
+                .and_then(Value::as_str);
+            if branch_mode == Some(mode.as_str()) {
+                return branch
+                    .get("required")
+                    .and_then(|v| v.as_array())
+                    .map(|arr| {
+                        arr.iter()
+                            .filter_map(|v| v.as_str().map(String::from))
+                            .collect()
+                    });
+            }
+        }
+        return one_of.first().and_then(|branch| {
+            branch
+                .get("required")
+                .and_then(|v| v.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|v| v.as_str().map(String::from))
+                        .collect()
+                })
+        });
+    }
+
+    if is_patch_flat_schema(parameters) {
+        let mode = args_json
+            .and_then(|raw| serde_json::from_str::<Value>(raw).ok())
+            .and_then(|v| v.get("mode").and_then(Value::as_str).map(String::from))
+            .unwrap_or_else(|| "replace".to_string());
+        return Some(patch_mode_required_fields(&mode));
+    }
+
+    parameters
+        .get("required")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        })
 }
 
 /// Normalize JSON Schema into a provider-safe shape.
@@ -1843,7 +1968,7 @@ mod tests {
             message: "missing field `path`".into(),
         };
 
-        let enriched = registry.enrich_invalid_args_error("read_file", &err);
+        let enriched = registry.enrich_invalid_args_error("read_file", &err, None);
         assert!(
             enriched.is_some(),
             "should return enriched error for InvalidArgs"
@@ -1868,9 +1993,86 @@ mod tests {
         let err = ToolError::NotFound("read_file".into());
         assert!(
             registry
-                .enrich_invalid_args_error("read_file", &err)
+                .enrich_invalid_args_error("read_file", &err, None)
                 .is_none()
         );
+    }
+
+    #[test]
+    fn lh61_annotate_llm_definitions_appends_budget_suffix_for_local_mutation_tools() {
+        let defs = vec![edgequake_llm::ToolDefinition::function(
+            "write_file",
+            "Write a file.",
+            serde_json::json!({}),
+        )];
+        let out = annotate_llm_definitions_for_local_turn(defs, "lmstudio", Some((27_852, 8192)));
+        assert!(out[0].function.description.contains("27852"));
+        assert!(out[0].function.description.contains("8192"));
+
+        let unchanged =
+            annotate_llm_definitions_for_local_turn(out.clone(), "anthropic", Some((27_852, 8192)));
+        assert_eq!(unchanged[0].function.description, out[0].function.description);
+
+        let no_budget = annotate_llm_definitions_for_local_turn(
+            vec![edgequake_llm::ToolDefinition::function(
+                "write_file",
+                "Write a file.",
+                serde_json::json!({}),
+            )],
+            "lmstudio",
+            None,
+        );
+        assert!(!no_budget[0].function.description.contains("Local turn limit"));
+    }
+
+    #[test]
+    fn lh62_required_fields_from_patch_flat_schema_respects_mode() {
+        let params = crate::tools::file_patch::patch_tool_parameters_json();
+        let replace_args = r#"{"mode":"replace","path":"a.md"}"#;
+        let fields =
+            required_fields_from_parameters(&params, Some(replace_args)).expect("fields");
+        assert!(fields.contains(&"path".to_string()));
+        assert!(fields.contains(&"old_string".to_string()));
+        assert!(!fields.contains(&"patch".to_string()));
+
+        let patch_args = r#"{"mode":"patch"}"#;
+        let patch_fields =
+            required_fields_from_parameters(&params, Some(patch_args)).expect("patch fields");
+        assert_eq!(patch_fields, vec!["mode".to_string(), "patch".to_string()]);
+    }
+
+    #[test]
+    fn lh64_patch_schema_passes_openai_compatible_provider_safe_gate() {
+        let params = crate::tools::file_patch::patch_tool_parameters_json();
+        let wire = openai_compatible_tool_parameters(&params);
+        assert_provider_safe_top_level_schema("patch", &wire);
+    }
+
+    #[test]
+    fn openai_compatible_tool_parameters_flattens_top_level_oneof() {
+        let oneof = json!({
+            "oneOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "mode": { "const": "a" },
+                        "foo": { "type": "string" }
+                    }
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "mode": { "const": "b" },
+                        "bar": { "type": "string" }
+                    }
+                }
+            ]
+        });
+        let flat = openai_compatible_tool_parameters(&oneof);
+        assert_eq!(flat["type"], "object");
+        assert!(flat.get("oneOf").is_none());
+        assert!(flat["properties"].get("foo").is_some());
+        assert!(flat["properties"].get("bar").is_some());
     }
 
     // ── coerce_tool_args tests ───────────────────────────────────────

--- a/crates/edgecrab-tools/src/tool_progress_tail.rs
+++ b/crates/edgecrab-tools/src/tool_progress_tail.rs
@@ -848,12 +848,20 @@ fn nonstreaming_wait_liveness(provider: &str, phase: NonStreamingWaitPhase) -> &
                 "non-streaming — still waiting on Copilot API"
             }
         },
-        _ => match phase {
+        "bedrock" => match phase {
             NonStreamingWaitPhase::Start => {
-                "non-streaming — waiting on provider until complete"
+                "Bedrock Converse — tool JSON arrives when complete (no tool stream yet)"
             }
             NonStreamingWaitPhase::Heartbeat => {
-                "non-streaming — provider may still be working"
+                "Bedrock Converse — still generating tool call"
+            }
+        },
+        _ => match phase {
+            NonStreamingWaitPhase::Start => {
+                "buffered API — response arrives when complete"
+            }
+            NonStreamingWaitPhase::Heartbeat => {
+                "buffered API — provider may still be working"
             }
         },
     }
@@ -1023,6 +1031,20 @@ pub fn llm_wait_progress_label(
     }
 }
 
+/// Compact status-bar label — avoids truncating the full shelf line mid-word.
+pub fn llm_wait_status_compact(
+    provider: &str,
+    has_tools: bool,
+    ctx: LlmWaitContext,
+) -> String {
+    let task = if has_tools { "tool turn" } else { "reply" };
+    if let Some(hint) = format_ctx_hint(ctx.prompt_tokens_estimated, ctx.context_length) {
+        format!("{provider} {task} · {hint}")
+    } else {
+        format!("{provider} {task}")
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1092,6 +1114,25 @@ mod tests {
     }
 
     #[test]
+    fn llm_wait_label_bedrock_uses_converse_not_local_nonstreaming() {
+        let ctx = LlmWaitContext {
+            prompt_tokens_estimated: Some(33_000),
+            context_length: Some(300_000),
+            prefill_pct: None,
+        };
+        let start = llm_wait_progress_label("bedrock", 0, true, ctx);
+        let wait = llm_wait_progress_label("bedrock", 31, true, ctx);
+        assert!(start.contains("Bedrock Converse"));
+        assert!(!start.contains("LM Studio"));
+        assert!(!start.contains("GEN/tok"));
+        assert!(wait.contains("Bedrock Converse"));
+        let compact = llm_wait_status_compact("bedrock", true, ctx);
+        assert!(compact.contains("bedrock tool turn"));
+        assert!(compact.contains("33k/300k"));
+        assert!(compact.len() < 48, "compact label must fit status bar: {compact}");
+    }
+
+    #[test]
     fn llm_wait_label_ollama_never_mentions_lm_studio() {
         let ctx = LlmWaitContext {
             prompt_tokens_estimated: Some(40_000),
@@ -1151,9 +1192,9 @@ mod tests {
     #[test]
     fn lh51_local_tool_turn_preflight_passes_through_max_arg_plan_line() {
         let plan_line =
-            "local tool turn: lmstudio / qwen · max_tokens=2048 · max_arg=6963B · reasoning=none";
+            "local tool turn: lmstudio / qwen · max_tokens=8192 · max_arg=27852B · reasoning=none";
         let shelf = format_local_tool_turn_preflight(plan_line);
-        assert!(shelf.contains("max_arg=6963B"));
+        assert!(shelf.contains("max_arg=27852B"));
     }
 
     #[test]

--- a/crates/edgecrab-tools/src/tools/file_patch.rs
+++ b/crates/edgecrab-tools/src/tools/file_patch.rs
@@ -228,6 +228,44 @@ async fn execute_replace_patch(args: ReplaceArgs, ctx: &ToolContext) -> Result<S
     Ok(result.to_string())
 }
 
+pub(crate) fn patch_tool_parameters_json() -> serde_json::Value {
+    // LM Studio / OpenAI-compatible validators require top-level `type: "object"`.
+    // `oneOf` is rejected before inference (GEN stays 0). Mode-specific requirements
+    // are enforced in Rust (`PatchArgs` + `required_fields_from_parameters`).
+    json!({
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+            "mode": {
+                "type": "string",
+                "enum": ["replace", "patch"],
+                "description": "replace: targeted find-and-replace; patch: V4A multi-file block"
+            },
+            "path": {
+                "type": ["string", "null"],
+                "description": "File path relative to working directory (replace mode)"
+            },
+            "old_string": {
+                "type": ["string", "null"],
+                "description": "Exact or fuzzy-matched text to replace (replace mode)"
+            },
+            "new_string": {
+                "type": ["string", "null"],
+                "description": "Replacement text — empty string deletes old_string (replace mode)"
+            },
+            "replace_all": {
+                "type": "boolean",
+                "description": "Replace all occurrences (default false — unique match required)"
+            },
+            "patch": {
+                "type": ["string", "null"],
+                "description": "V4A patch block starting with '*** Begin Patch' (patch mode)"
+            }
+        },
+        "required": ["mode", "path", "old_string", "new_string", "replace_all", "patch"]
+    })
+}
+
 #[async_trait]
 impl ToolHandler for PatchTool {
     fn name(&self) -> &'static str {
@@ -259,38 +297,7 @@ impl ToolHandler for PatchTool {
                  new_string payload must stay at or under {DEFAULT_MAX_MUTATION_PAYLOAD_BYTES} \
                  bytes ({DEFAULT_MAX_MUTATION_PAYLOAD_KIB} KiB) per call."
             ),
-            parameters: json!({
-                "type": "object",
-                "additionalProperties": false,
-                "properties": {
-                    "mode": {
-                        "type": "string",
-                        "enum": ["replace", "patch"],
-                        "description": "replace = targeted find-and-replace, patch = V4A multi-file patch block"
-                    },
-                    "path": {
-                        "type": ["string", "null"],
-                        "description": "File path relative to working directory. Required for replace mode; use null for patch mode."
-                    },
-                    "old_string": {
-                        "type": ["string", "null"],
-                        "description": "String to find and replace. Required for replace mode; use null for patch mode."
-                    },
-                    "new_string": {
-                        "type": ["string", "null"],
-                        "description": "String to replace old_string with. Required for replace mode; use empty string to delete text and null for patch mode."
-                    },
-                    "replace_all": {
-                        "type": "boolean",
-                        "description": "Replace all occurrences. Set explicitly to true or false."
-                    },
-                    "patch": {
-                        "type": ["string", "null"],
-                        "description": "V4A patch block for patch mode, starting with '*** Begin Patch'. Use null for replace mode."
-                    }
-                },
-                "required": ["mode", "path", "old_string", "new_string", "replace_all", "patch"]
-            }),
+            parameters: patch_tool_parameters_json(),
             strict: Some(true),
         }
     }
@@ -1603,5 +1610,20 @@ mod tests {
                 .contains("Split the refactor into multiple focused apply_patch calls")
         );
         assert!(!dir.path().join("huge.txt").exists());
+    }
+
+    #[test]
+    fn lh62_patch_schema_replace_mode_fields() {
+        let params = super::patch_tool_parameters_json();
+        assert_eq!(params["type"], "object");
+        assert!(params.get("oneOf").is_none());
+        assert_eq!(params["properties"]["mode"]["enum"], json!(["replace", "patch"]));
+    }
+
+    #[test]
+    fn lh62_patch_schema_patch_mode_fields() {
+        let params = super::patch_tool_parameters_json();
+        assert_eq!(params["properties"]["patch"]["type"], json!(["string", "null"]));
+        assert_eq!(params["properties"]["path"]["type"], json!(["string", "null"]));
     }
 }

--- a/specs/014-improve-local-harness/004-homelab-evidence.md
+++ b/specs/014-improve-local-harness/004-homelab-evidence.md
@@ -142,7 +142,27 @@ Recovery text (verbatim from DB):
 
 ---
 
-## 6. Screenshot correlation (2026-06-14 ~16:35 local)
+## 6. GEN=0 — schema rejection (2026-06-14, gemma-4-e4b)
+
+**Symptom:** LM Studio **GEN 0** for 26–88s+; EdgeCrab shelf shows `composing tool call`.
+
+**Log signature (40× in `agent.jsonl`):**
+
+```text
+lmstudio API 400 — invalid_union_discriminator
+path: [N, "function", "parameters", "type"]
+Expected 'object'
+```
+
+**Cause:** `patch` tool exported top-level `oneOf` instead of `type: "object"`. LM Studio Zod validator rejects the request **before** the model runs.
+
+**Fix:** P6 — flat object schema + `openai_compatible_tool_parameters()` safety net (**LH-64**).
+
+**Distinguish from slow prefill:** After fix, GEN climbs within seconds once prefill completes; 400 errors disappear from logs.
+
+---
+
+## 7. Screenshot correlation (2026-06-14 ~16:35 local)
 
 | UI signal | Evidence interpretation |
 |-----------|-------------------------|
@@ -155,7 +175,7 @@ Recovery text (verbatim from DB):
 
 ---
 
-## 7. Evidence → layer mapping
+## 8. Evidence → layer mapping
 
 ```text
   OBSERVATION                          LAYER

--- a/specs/014-improve-local-harness/005-code-anchors.md
+++ b/specs/014-improve-local-harness/005-code-anchors.md
@@ -23,8 +23,8 @@ Implementation map from first principles to source files.
 | `LocalStructuralPrunePhase` | `Preflight` \| `LengthRecovery` |
 | `gate_local_structural_prune` | Phase-specific gate (threshold vs always) |
 | `try_apply_structural_tool_output_prune` | Gate + apply; returns `StructuralPruneOutcome` |
-| `local_structural_compress_token_threshold` | `ctx × 0.22` (P3 mid-band) |
-| `should_local_structural_compress` | Between 22% and 50% ctx |
+| `local_structural_compress_token_threshold` | `ctx × 0.20` (P3/P9 mid-band; env override) |
+| `should_local_structural_compress` | Between 20% and 50% ctx |
 | `try_local_midband_structural_compress` | Applies `compress_structural_only` when gated |
 | `log_local_prefill_prune` | Structured INFO (`preflight` \| `length_recovery`) |
 | `log_local_tool_length_failure` | Structured WARN for investigation |
@@ -39,11 +39,11 @@ Implementation map from first principles to source files.
   output_token_budget_for_tool_turn()
        │
        └── min(provider_cap, mutation_payload_tokens + envelope, LOCAL_TOOL_TURN_ABS_MAX_TOKENS)
-                    default 2048
+                    default 8192
 
   max_tool_argument_bytes()
        │
-       └── output_budget × TOOL_ARG_CHARS_PER_TOKEN (4) × 0.85  →  ~6963 B
+       └── output_budget × TOOL_ARG_CHARS_PER_TOKEN (4) × 0.85  →  ~27852 B @ 8192
 ```
 
 | Symbol | Role |
@@ -51,7 +51,10 @@ Implementation map from first principles to source files.
 | `check_tool_argument_budget` | Pre-dispatch reject (only if tool_calls parsed) |
 | `length_without_tools_recovery_message` | After `finish_reason=length` + no tools (P2) |
 | `stream_interrupted_recovery_message` | After stream interrupt / timeout mid-draft |
-| `LOCAL_TOOL_TURN_ABS_MAX_TOKENS` | `2048` (env: `EDGECRAB_LOCAL_TOOL_MAX_TOKENS`) |
+| `LOCAL_TOOL_TURN_ABS_MAX_TOKENS` | `8192` (env: `EDGECRAB_LOCAL_TOOL_MAX_TOKENS`; yaml: `local_inference.max_tool_turn_tokens`) |
+| `annotate_llm_definitions_for_local_turn` | P7 — appends live budget suffix to mutation tools |
+| `patch_tool_parameters_json` | P6 — flat `type: "object"` (nullable mode fields; no top-level `oneOf`) |
+| `openai_compatible_tool_parameters` | P6/LH-64 — wire-safe export; flattens top-level `oneOf` before API |
 
 **Gap (documented):** guard runs **post-API**, not pre-API — see [002-first-principles-why.md](./002-first-principles-why.md) Layer 3.
 

--- a/specs/014-improve-local-harness/006-solution-plan.md
+++ b/specs/014-improve-local-harness/006-solution-plan.md
@@ -34,6 +34,10 @@ A change enters **Verified plan** only when **all** of the following hold:
   P3     L1      SHIPPED   LH-32..33 (mid-band structural compress @ 22% ctx)
   P4     tools   SHIPPED   LH-40 (local_write_create_dirs config)
   P5     UX      SHIPPED   LH-50..51 (shelf max_arg_bytes)
+  P6     L2      SHIPPED   LH-62 + LH-64 (patch flat object schema; LM Studio GEN=0 fix)
+  P7     L2      SHIPPED   LH-61 (live budget on tool defs)
+  P8     L2      SHIPPED   LH-60 (max_tool_turn_tokens config @ 8192)
+  P9     L1      SHIPPED   LH-63 (mid-band @ 20% — homelab 57k gap)
 ```
 
 ### P0 — Local tool-turn completion policy ✅ VERIFIED
@@ -113,12 +117,68 @@ A change enters **Verified plan** only when **all** of the following hold:
 
 | Change | Gate |
 |--------|------|
-| `LOCAL_STRUCTURAL_COMPRESS_THRESHOLD_RATIO = 0.22` | **LH-32** |
+| `LOCAL_STRUCTURAL_COMPRESS_THRESHOLD_RATIO = 0.20` | **LH-32**, **LH-63** |
 | `try_local_midband_structural_compress` → `compress_structural_only` | **LH-33** |
 | Wired in `conversation.rs` before preflight prune | **LH-33** |
 | Shelf `format_local_structural_compress_notice` | **LH-50** |
 
-**Formula:** `estimated > ctx × 0.22` **and** `estimated < ctx × 0.50` (local tool turns only).
+**Formula:** `estimated > ctx × 0.20` **and** `estimated < ctx × 0.50` (local tool turns only).
+
+**Why 0.20 (not 0.22):** homelab agent.jsonl reports ~56–57k @ 262k ctx; at 0.22 threshold = 57 671 — sessions at 57 000 never compress.
+
+Override: `EDGECRAB_LOCAL_STRUCTURAL_COMPRESS_RATIO`.
+
+---
+
+### P6 — Patch flat `object` schema (LM Studio GEN=0) ✅ VERIFIED
+
+**WHY (two constraints):**
+
+1. `mode:replace` and `mode:patch` require different fields — flat `required` caused InvalidArgs loops on homelab outline fix.
+2. LM Studio / OpenAI-compatible validators require top-level `type: "object"`. A top-level `oneOf` is rejected **before inference** (`invalid_union_discriminator` → **GEN stays 0** while EdgeCrab waits on HTTP).
+
+**First-principles fix:** flat nullable object on the wire; mode-specific requirements enforced in Rust only.
+
+| Change | Gate |
+|--------|------|
+| `patch_tool_parameters_json()` — `type: "object"`, nullable mode fields | **LH-62** |
+| `required_fields_from_parameters(..., args_json)` mode-aware | **LH-62** |
+| `openai_compatible_tool_parameters()` flattens stray top-level `oneOf` | **LH-64** |
+| `all_exported_tool_definitions_have_provider_safe_top_level_schemas` | **LH-64** |
+
+---
+
+### P7 — Live byte budget on mutation tool defs ✅ VERIFIED
+
+**WHY:** Model sees exact arg cap at API time, not stale prompt text.
+
+| Change | Gate |
+|--------|------|
+| `annotate_llm_definitions_for_local_turn` | **LH-61** |
+| Wired in `conversation.rs` before local API | **LH-61** (e2e) |
+
+---
+
+### P8 — `local_inference.max_tool_turn_tokens` ✅ VERIFIED
+
+**WHY:** 2048 completion cap → ~6963 B arg budget; homelab PPT scaffolds hit `finish_reason=length`.
+
+| Change | Gate |
+|--------|------|
+| Default **8192** → ~**27852 B** arg cap | **LH-60** |
+| `local_tool_turn_absolute_max_tokens` env > yaml > default | **LH-60** |
+| `local_inference.max_tool_turn_tokens` in config | **LH-60** |
+
+---
+
+### P9 — Mid-band threshold lowered to 20% ✅ VERIFIED
+
+**WHY:** Deterministic gap at homelab 57k with 0.22 ratio (57 671 threshold).
+
+| Change | Gate |
+|--------|------|
+| `LOCAL_STRUCTURAL_COMPRESS_THRESHOLD_RATIO = 0.20` | **LH-63** |
+| `local_structural_compress_threshold_ratio()` env override | **LH-63** |
 
 ---
 
@@ -160,14 +220,14 @@ local_inference:
   [compress @ 50% ctx]          only if estimated > 131k @ 262k ctx
          │
          ▼
-  [P3 mid-band compress?]         IF 22% < prompt < 50% ctx         ← LH-32..33
+  [P3 mid-band compress?]         IF 20% < prompt < 50% ctx         ← LH-32..33, LH-63
          │
          ▼
   [P1a preflight prune?]        IF prompt > min(32k, ctx/8)     ← LH-06..09, LH-30..31
          │                        prune_tool_outputs + spill
          ▼
-  [P0 completion policy]        reasoning=none, max_tokens=2048,
-         │                        tool_choice=required            ← LH-01..05
+  [P0 completion policy]        reasoning=none, max_tokens=8192,
+         │                        tool_choice=required            ← LH-01..05, LH-60
          ▼
   POST /v1/chat/completions (non-streaming, no retry)           ← LH-03
          │
@@ -225,6 +285,10 @@ These violate admission rules or official transport semantics. Do not re-propose
   DONE     P3  ── LH-32/33 mid-band structural compress
   DONE     P4  ── LH-40 local_write_create_dirs
   DONE     P5  ── LH-50/51 shelf max_arg_bytes
+  DONE     P6  ── LH-62 patch flat object + LH-64 provider-safe gate
+  DONE     P7  ── LH-61 annotate tool defs
+  DONE     P8  ── LH-60 max_tool_turn_tokens @ 8192
+  DONE     P9  ── LH-63 mid-band @ 20%
   FROZEN   B6 only (optional AGENTS.md link)
 ```
 
@@ -232,7 +296,8 @@ These violate admission rules or official transport semantics. Do not re-propose
 
 ```bash
 cargo test -p edgecrab-core --test local_prefill_prune_e2e
-cargo test -p edgecrab-core prefill structural_prefill
+cargo test -p edgecrab-core --test local_harness_geometry_e2e
+cargo test -p edgecrab-core prefill structural_prefill lh60 lh61 lh62 lh63
 cargo test -p edgecrab-tools mutation_turn lh20_length local_prefill
 cargo clippy -p edgecrab-core -p edgecrab-tools -- -D warnings
 ```

--- a/specs/014-improve-local-harness/007-acceptance-criteria.md
+++ b/specs/014-improve-local-harness/007-acceptance-criteria.md
@@ -22,6 +22,9 @@ Cross-ref: [006-solution-plan.md](./006-solution-plan.md) · [005-code-anchors.m
   P3      LH-32 .. LH-33      cargo test -p edgecrab-core --test local_prefill_prune_e2e lh3
   P4      LH-40               cargo test -p edgecrab-tools lh40
   P5      LH-50 .. LH-51      cargo test -p edgecrab-tools lh5
+  P6-P8   LH-60 .. LH-64      cargo test -p edgecrab-core --test local_harness_geometry_e2e
+                               cargo test -p edgecrab-tools --lib lh64 all_exported_tool
+  P9      LH-63               cargo test -p edgecrab-core --test local_prefill_prune_e2e lh63
   BACKLOG B6                  optional AGENTS.md link
 ```
 
@@ -35,7 +38,7 @@ Cross-ref: [006-solution-plan.md](./006-solution-plan.md) · [005-code-anchors.m
 | **LH-02** | `tool_choice: required` when tools + local provider | `local_provider_policy::local_tool_choice_required_for_local_tool_turns` |
 | **LH-03** | No transport retry on local Timeout/NetworkError | `local_provider_policy::blocks_transport_retry_only_for_local_timeout_and_network` |
 | **LH-04** | API `max_tokens` = `output_token_budget_for_tool_turn` | `mutation_turn_policy` + `local_provider_policy` DRY tests |
-| **LH-05** | Max arg bytes = **6963** @ default (`2048×4×0.85`) | `mutation_turn_policy` unit (`assert_eq!(max, 6963)`) |
+| **LH-05** | Max arg bytes = **27852** @ default (`8192×4×0.85`) | `mutation_turn_policy` unit (`local_default_max_tool_argument_bytes`) |
 | **LH-10** | Non-streaming tool request serializes `reasoning_effort` | `edgequake-llm` `test_chat_request_with_tools_reasoning_effort_serialized` |
 
 ### P0 optional live (ignored — not plan gate)
@@ -115,6 +118,23 @@ cargo test -p edgecrab-tools lh20_length
 | **LH-33** | Structural compress shrinks high-band fixture >2× | `local_prefill_prune_e2e::lh33_local_structural_compress_reduces_high_band_tokens` |
 | **LH-33b** | Gate formula mid-band only | `local_provider_policy::should_local_structural_compress_mid_band_only` |
 | **LH-50** | Shelf compress notice shows token drop | `tool_progress_tail::lh50_local_structural_compress_notice_mentions_token_drop` |
+| **LH-63** | Homelab ~57k exceeds 20% threshold (was gap @ 0.22) | `local_prefill_prune_e2e::lh63_homelab_57k_band_triggers_structural_compress_at_20pct` |
+
+---
+
+## P6–P8 — Output geometry + schema (CI required)
+
+| ID | Invariant | Test |
+|----|-----------|------|
+| **LH-60** | Config `max_tool_turn_tokens` resolves; default 8192 → 27852 B | `local_harness_geometry_e2e::lh60_e2e_*`, `local_provider_policy::lh60_*` |
+| **LH-61** | Local turn annotates mutation tool defs with live budget | `local_harness_geometry_e2e::lh61_e2e_*`, `registry::lh61_*` |
+| **LH-62** | Patch flat object + mode-aware `required_fields` on InvalidArgs | `local_harness_geometry_e2e::lh62_e2e_patch_flat_schema_*`, `file_patch::lh62_*`, `registry::lh62_*` |
+| **LH-64** | Every exported tool has top-level `type: "object"` (no `oneOf` on wire) | `registry::all_exported_tool_definitions_have_provider_safe_top_level_schemas`, `registry::lh64_*`, `registry::openai_compatible_tool_parameters_*` |
+
+```bash
+cargo test -p edgecrab-core --test local_harness_geometry_e2e
+cargo test -p edgecrab-tools --lib all_exported_tool_definitions lh64 openai_compatible
+```
 
 ---
 

--- a/specs/014-improve-local-harness/README.md
+++ b/specs/014-improve-local-harness/README.md
@@ -15,8 +15,8 @@ This spec formalizes **why** EdgeCrab appears “stuck” on local providers, wh
 | [003-official-references.md](./003-official-references.md) | LM Studio, OpenAI, Qwen3, vLLM — authoritative external grounding |
 | [004-homelab-evidence.md](./004-homelab-evidence.md) | Logs + SQLite sessions; quantitative failure signatures |
 | [005-code-anchors.md](./005-code-anchors.md) | EdgeCrab / edgequake-llm implementation cross-ref |
-| [006-solution-plan.md](./006-solution-plan.md) | **Verified plan** (P0–P5 complete) |
-| [007-acceptance-criteria.md](./007-acceptance-criteria.md) | CI gates LH-01..LH-51 |
+| [006-solution-plan.md](./006-solution-plan.md) | **Verified plan** (P0–P9 complete) |
+| [007-acceptance-criteria.md](./007-acceptance-criteria.md) | CI gates LH-01..LH-64 |
 
 **Related specs (cross-ref):**
 
@@ -40,7 +40,7 @@ This spec formalizes **why** EdgeCrab appears “stuck” on local providers, wh
   ROOT CAUSE STACK (independent constraints)
   ┌──────────────────────────────────────────────────────────────┐
   │ L1 INPUT  — large prompt (34–57k) → slow prefill             │
-  │ L2 OUTPUT — tool JSON must fit in max_tokens=2048 (~6963 B) │
+  │ L2 OUTPUT — tool JSON must fit in max_tokens=8192 (~27852 B) │
   │ L3 CONTROL— recovery adds tokens; preflight now covers 34k+ band │
   └──────────────────────────────────────────────────────────────┘
 ```
@@ -59,8 +59,9 @@ This spec formalizes **why** EdgeCrab appears “stuck” on local providers, wh
 | **Tool turn** | ReAct iteration where `tools` non-empty and model must emit `tool_calls` |
 | **Non-streaming tool turn** | Single HTTP response after full generation (EdgeCrab policy for LM Studio) |
 | **Output budget** | `max_tokens` cap on completion stream (includes reasoning on some stacks) |
-| **Arg budget** | Max JSON argument bytes derivable from output budget (~6963 B local) |
+| **Arg budget** | Max JSON argument bytes derivable from output budget (~27852 B local @ 8192 tok) |
 | **Structural prefill prune** | `prune_tool_outputs` + spill — no LLM summarization |
+| **GEN=0** | LM Studio generation counter stuck at 0 — usually schema rejection (400) before prefill, not slow model |
 
 ---
 
@@ -69,7 +70,9 @@ This spec formalizes **why** EdgeCrab appears “stuck” on local providers, wh
 | Variable | Default | Effect |
 |----------|---------|--------|
 | `EDGECRAB_LOCAL_PREFILL_PRUNE_TOKENS` | `min(32000, ctx/8)` | Preflight prune threshold |
-| `local_inference.write_create_dirs` | `false` | Default `write_file` create_dirs when omitted |
-| `EDGECRAB_LOCAL_TOOL_MAX_TOKENS` | `2048` | Absolute completion cap for local tool turns |
+| `EDGECRAB_LOCAL_STRUCTURAL_COMPRESS_RATIO` | `0.20` | Mid-band structural compress threshold (ctx × ratio) |
+| `local_inference.write_create_dirs` | `true` | Default `write_file` create_dirs when omitted |
+| `local_inference.max_tool_turn_tokens` | `8192` | Absolute completion cap (env overrides) |
+| `EDGECRAB_LOCAL_TOOL_MAX_TOKENS` | `8192` | Env override for absolute completion cap |
 | `LMSTUDIO_TIMEOUT_SECONDS` | `600` | HTTP client timeout (no retry on local) |
 | `RUST_LOG=edgecrab::local_llm=info` | — | Structured investigation logs |


### PR DESCRIPTION
## Summary
- Fix LM Studio GEN=0 by exporting patch tool as flat `type: "object"` (top-level `oneOf` caused 400 `invalid_union_discriminator` before inference)
- Add `openai_compatible_tool_parameters()` safety net and LH-64 provider-safe schema gate for all exported tools
- Raise local tool-turn output budget to 8192 (~27852 B arg cap), mid-band structural compress at 20%, live budget annotation on mutation tools
- Update spec 014 (P6–P9, LH-64, homelab GEN=0 evidence)

## Test plan
- [x] `cargo test -p edgecrab-core --test local_harness_geometry_e2e`
- [x] `cargo test -p edgecrab-core --test local_prefill_prune_e2e`
- [x] `cargo test -p edgecrab-tools --lib all_exported_tool_definitions lh64 patch_schema`
- [x] `cargo clippy -p edgecrab-core -p edgecrab-tools -- -D warnings`
- [ ] Homelab: retry PPT on `lmstudio/google/gemma-4-e4b` — GEN should climb; no 400 in agent.jsonl


Made with [Cursor](https://cursor.com)