### PR TITLE
chore: pin edgequake-llm 0.6.25 from crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2472,7 +2472,9 @@ dependencies = [
 
 [[package]]
 name = "edgequake-llm"
-version = "0.6.24"
+version = "0.6.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f96bf3c2e3ec820d0304315ddfdc26589b88a058bd7399798383b9c1ec0b9f70"
 dependencies = [
  "anyhow",
  "async-openai",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,8 +69,8 @@ lsp-types = { version = "0.97.0", features = ["proposed"] }
 regex = "1"
 url = "2"
 
-# LLM backend — crates.io pin (git tag stripped on `cargo publish`; v0.9.0 used version-only).
-edgequake-llm = { path = "../edgequake-llm", features = ["bedrock"] }
+# LLM backend — crates.io pin (v0.6.25: LM Studio metadata + tool-turn reasoning_effort).
+edgequake-llm = { version = "0.6.25", features = ["bedrock"] }
 
 # Image processing (vision tool: resize/compress before base64 encoding)
 image = { version = "0.25", default-features = false, features = ["png", "jpeg"] }


### PR DESCRIPTION
## Summary
- Pin `edgequake-llm = "0.6.25"` from crates.io (drops `../edgequake-llm` path override)
- Fixes CI failures where runners cannot resolve the sibling path dependency

## Depends on
- [edgequake-llm #78](https://github.com/raphaelmansuy/edgequake-llm/pull/78) — merged and published as **v0.6.25**

## Test plan
- [x] `cargo build -p edgecrab-cli` with registry 0.6.25
- [ ] CI Rust lint & tests (ubuntu + macos)


Made with [Cursor](https://cursor.com)